### PR TITLE
# Transactions MVP — Portfolio Feed (Ethereum)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import authRoutes from "./routes/auth.routes";
 import cookieParser from "cookie-parser";
 import healthRouter from "./routes/health.routes";
 import portfolioRouter from "./routes/portfolio.routes";
+import txsRouter from "./routes/txs.routes";
 
 const app = express();
 app.use(cors());
@@ -20,6 +21,8 @@ app.use("/api/health", healthRouter);
 app.use("/api/auth", authRoutes);
 
 app.use("/api/portfolio", portfolioRouter);
+
+app.use("/api/portfolio", txsRouter);
 
 const PORT = process.env.PORT ?? "8080";
 app.listen(PORT, () => {

--- a/backend/src/routes/txs.routes.ts
+++ b/backend/src/routes/txs.routes.ts
@@ -3,7 +3,7 @@ import { getLast20Transfers } from "../services/txs.service";
 
 const router = Router();
 
-// GET /api/portfolio/txs/:address?type=income|expense|swap
+// GET /api/portfolio/txs/:address?type=income|expense|swap|gas
 router.get("/txs/:address", async (req, res) => {
   const address = String(req.params.address || "").trim();
   if (!address) {

--- a/backend/src/routes/txs.routes.ts
+++ b/backend/src/routes/txs.routes.ts
@@ -3,7 +3,7 @@ import { getLast20Transfers } from "../services/txs.service";
 
 const router = Router();
 
-// GET /api/portfolio/txs/:address?type=income|expense|swap|gas
+// GET /api/portfolio/txs/:address?kind=all|transactions|tokens&type=income|expense|swap|gas&cursor=...&limit=20
 router.get("/txs/:address", async (req, res) => {
   const address = String(req.params.address || "").trim();
   if (!address) {
@@ -12,18 +12,26 @@ router.get("/txs/:address", async (req, res) => {
     });
   }
 
-  const type =
-    (req.query.type as "income" | "expense" | "swap" | undefined) || undefined;
   const kind =
-    (req.query.kind as "all" | "transactions" | "tokens" | undefined) ||
+    (req.query.kind as "all" | "transactions" | "tokens" | undefined) || "all";
+
+  const type =
+    (req.query.type as "income" | "expense" | "swap" | "gas" | undefined) ||
     undefined;
 
+  const cursor = (req.query.cursor as string) || null;
+  const limit = Math.max(1, Math.min(100, Number(req.query.limit) || 20));
+
   try {
-    const data = await getLast20Transfers(address, type, kind);
+    // make sure your service signature matches: (address, type, kind, cursor, limit)
+    const data = await getLast20Transfers(address, type, kind, cursor, limit);
     return res.json(data);
-  } catch (e) {
+  } catch (e: any) {
     return res.status(502).json({
-      error: { code: "UpstreamError", message: "Failed to fetch transfers" },
+      error: {
+        code: "UpstreamError",
+        message: e?.message || "Failed to fetch transfers",
+      },
     });
   }
 });

--- a/backend/src/routes/txs.routes.ts
+++ b/backend/src/routes/txs.routes.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+import { getLast20Transfers } from "../services/txs.service";
+
+const router = Router();
+
+// GET /api/portfolio/txs/:address?type=income|expense|swap
+router.get("/txs/:address", async (req, res) => {
+  const address = String(req.params.address || "").trim();
+  if (!address) {
+    return res.status(400).json({
+      error: { code: "BadRequest", message: "Address is required" },
+    });
+  }
+
+  const type =
+    (req.query.type as "income" | "expense" | "swap" | undefined) || undefined;
+  const kind =
+    (req.query.kind as "all" | "transactions" | "tokens" | undefined) ||
+    undefined;
+
+  try {
+    const data = await getLast20Transfers(address, type, kind);
+    return res.json(data);
+  } catch (e) {
+    return res.status(502).json({
+      error: { code: "UpstreamError", message: "Failed to fetch transfers" },
+    });
+  }
+});
+
+export default router;

--- a/backend/src/services/txs.service.ts
+++ b/backend/src/services/txs.service.ts
@@ -7,7 +7,7 @@ type TxRow = {
   network: "eth-mainnet";
   wallet: string;
   direction: "in" | "out";
-  type: "income" | "expense" | "swap";
+  type: "income" | "expense" | "swap" | "gas";
   asset: {
     symbol: string | null;
     contract: string | null;

--- a/backend/src/services/txs.service.ts
+++ b/backend/src/services/txs.service.ts
@@ -1,0 +1,138 @@
+import { alchemy } from "../utils/alchemy";
+
+type TxRow = {
+  ts: string;
+  hash: string;
+  network: "eth-mainnet";
+  wallet: string;
+  direction: "in" | "out";
+  type: "income" | "expense" | "swap";
+  asset: {
+    symbol: string | null;
+    contract: string | null;
+    decimals: number | null;
+  };
+  qty: string; // raw decimal string from Alchemy
+  usdAtTs: number | null; // fill later
+  priceUsdAtTs: number | null; // fill later
+  counterparty: { address: string | null; label: string | null };
+  fee: { eth: string | null; usd: number | null } | null; // fill later
+  isApprox: boolean; // for pricing later
+};
+
+function normAddr(a?: string | null) {
+  return a ? a.toLowerCase() : null;
+}
+
+const kindToCategories = (kind?: string) => {
+  switch ((kind || "all").toLowerCase()) {
+    case "transactions":
+      return ["external", "internal"] as const; // ETH only (normal + internal)
+    case "tokens":
+      return ["erc20"] as const; // ERC-20 only
+    default:
+      return ["external", "internal", "erc20"] as const; // everything (default)
+  }
+};
+
+async function pullTransfers(
+  direction: "in" | "out",
+  address: string,
+  categories: readonly ("external" | "internal" | "erc20")[],
+  target: number
+) {
+  const paramsBase =
+    direction === "out" ? { fromAddress: address } : { toAddress: address };
+
+  let pageKey: string | undefined;
+  const acc: any[] = [];
+  const MAX_PAGES = 6; // safety cap
+
+  for (let i = 0; i < MAX_PAGES; i++) {
+    const res = await alchemy.core.getAssetTransfers({
+      ...paramsBase,
+      category: categories as any,
+      withMetadata: true,
+      order: "desc",
+      maxCount: 100n,
+      pageKey,
+    });
+    acc.push(...(res.transfers || []));
+    if (!res.pageKey || acc.length >= target) break;
+    pageKey = res.pageKey;
+  }
+  return acc;
+}
+
+export async function getLast20Transfers(
+  address: string,
+  type?: "income" | "expense" | "swap",
+  kind?: "all" | "transactions" | "tokens"
+) {
+  const acct = address.toLowerCase();
+  const categories = kindToCategories(kind);
+
+  // Pull *both* directions with paging; over-fetch to ensure we can slice 20 after merging
+  const NEED = 80; // fetch enough to classify swaps then slice to 20
+  const [outRaw, inRaw] = await Promise.all([
+    pullTransfers("out", acct, categories, NEED),
+    pullTransfers("in", acct, categories, NEED),
+  ]);
+
+  const rows: TxRow[] = [];
+  const pushRows = (items: any[], direction: "in" | "out") => {
+    for (const t of items ?? []) {
+      const isEthExternal =
+        t.category === "external" || t.category === "internal";
+      const sym = isEthExternal ? "ETH" : t.asset ?? null;
+      const contract = isEthExternal ? null : normAddr(t.rawContract?.address);
+      const qty = String(t.value ?? "0");
+      const ts = new Date(
+        t.metadata?.blockTimestamp ?? Date.now()
+      ).toISOString();
+      const hash = t.hash ?? t.uniqueId ?? "";
+      const counterparty =
+        direction === "in" ? normAddr(t.from) : normAddr(t.to);
+
+      rows.push({
+        ts,
+        hash,
+        network: "eth-mainnet",
+        wallet: acct,
+        direction,
+        type: direction === "in" ? "income" : "expense", // temp; swap-marking below
+        asset: { symbol: sym, contract, decimals: isEthExternal ? 18 : null },
+        qty,
+        usdAtTs: null,
+        priceUsdAtTs: null,
+        counterparty: { address: counterparty, label: null },
+        fee: null,
+        isApprox: false,
+      });
+    }
+  };
+
+  pushRows(outRaw, "out");
+  pushRows(inRaw, "in");
+
+  // Mark swaps: any hash with both in & out → set both legs to "swap"
+  const byHash = new Map<string, { hasIn: boolean; hasOut: boolean }>();
+  for (const r of rows) {
+    const e = byHash.get(r.hash) ?? { hasIn: false, hasOut: false };
+    if (r.direction === "in") e.hasIn = true;
+    else e.hasOut = true;
+    byHash.set(r.hash, e);
+  }
+  for (const r of rows) {
+    const e = byHash.get(r.hash);
+    if (e && e.hasIn && e.hasOut) r.type = "swap";
+  }
+
+  // Sort newest-first, then slice *exactly* 20 (after optional type filter)
+  rows.sort((a, b) => (a.ts < b.ts ? 1 : a.ts > b.ts ? -1 : 0));
+  let items = rows;
+  if (type) items = items.filter((r) => r.type === type);
+  items = items.slice(0, 20);
+
+  return { items, nextCursor: null, hasMore: items.length === 20 }; // cursor comes later
+}

--- a/frontend/src/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/src/components/dashboard/AllTransactionsTab.tsx
@@ -1,27 +1,15 @@
-import { useState } from "react";
-import {
-  TrendingUp,
-  TrendingDown,
-  Repeat,
-  Coins,
-  Filter,
-  Search,
-  Calendar,
-  Eye,
-} from "lucide-react";
+// --- File: src/components/dashboard/AllTransactionsTab.tsx
+// Replaces the placeholder version. Fetches real data from backend and supports a single filter: transaction type.
+// Assumes backend route: GET /api/portfolio/txs/:address?kind=all&limit=20&cursor=...
+// Reads the wallet address from the URL (e.g., /dashboard?address=vitalik.eth)
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
-import { Slider } from "@/components/ui/slider";
-import { Calendar as CalendarComponent } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import {
   Table,
   TableBody,
@@ -30,179 +18,238 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
+import {
+  Eye,
+  ExternalLink,
+  RefreshCw,
+  TrendingDown,
+  TrendingUp,
+  Repeat,
+  Fuel,
+} from "lucide-react";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
-import { format } from "date-fns";
 
-interface Transaction {
-  id: string;
-  date: string;
-  description: string;
-  amount: string;
-  usdValue: number;
+// --- Types aligned with backend JSON shape
+export type TxType = "income" | "expense" | "swap" | "gas";
+export type Direction = "in" | "out";
+
+export interface TxRow {
+  ts: string; // ISO timestamp
+  blockNumber: number;
   hash: string;
-  type: "income" | "expense" | "swap";
-  network: string;
-  walletId: string;
+  network: string; // e.g. "eth-mainnet"
+  wallet?: string; // may be present in feed wrapper; not required for row
+  direction: Direction;
+  type: TxType;
+  asset: { symbol: string; contract: string | null; decimals: number };
+  qty: string; // decimal string
+  priceUsdAtTs: number | null;
+  usdAtTs: number | null;
+  counterparty?: { address: string; label: string | null };
+  fee?: null | {
+    asset: "ETH";
+    qty: string;
+    priceUsdAtTs: number | null;
+    usdAtTs: number | null;
+  };
+  isApprox?: boolean;
 }
 
-interface AllTransactionsTabProps {
-  transactions: Transaction[];
-  connectedWallets: Array<{
-    id: string;
-    name: string;
-    address: string;
-    network: string;
-  }>;
-  getWalletName: (walletId: string) => string;
+export interface TxFeed {
+  network: "eth-mainnet";
+  wallet: { input: string; address: string; ens: string | null };
+  window: { from: string | null; to: string | null };
+  page: { limit: number; cursor: string | null; nextCursor: string | null };
+  items: TxRow[];
 }
 
-const AllTransactionsTab = ({
-  transactions,
-  connectedWallets,
-  getWalletName,
-}: AllTransactionsTabProps) => {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedTypes, setSelectedTypes] = useState<string[]>(["all"]);
-  const [selectedNetworks, setSelectedNetworks] = useState<string[]>(["all"]);
-  const [selectedWallets, setSelectedWallets] = useState<string[]>(["all"]);
-  const [amountRange, setAmountRange] = useState([0, 50000]);
-  const [dateFrom, setDateFrom] = useState<Date>();
-  const [dateTo, setDateTo] = useState<Date>();
-  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
-  const [visibleColumns, setVisibleColumns] = useState({
+const fmtUSD = (n: number | null | undefined) =>
+  n == null
+    ? "—"
+    : n.toLocaleString(undefined, {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 2,
+      });
+
+const fmtQty = (qty: string, dir: Direction) => {
+  const sign = dir === "in" ? "+" : "-";
+  return `${sign}${qty}`;
+};
+
+const shortAddr = (a?: string) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : "—");
+
+const typeColor = (t: TxType) =>
+  ({
+    income: "text-green-600",
+    expense: "text-red-600",
+    swap: "text-blue-600",
+    gas: "text-amber-600",
+  }[t]);
+
+const typeIcon = (t: TxType) => {
+  switch (t) {
+    case "income":
+      return <TrendingUp className="w-4 h-4" />;
+    case "expense":
+      return <TrendingDown className="w-4 h-4" />;
+    case "swap":
+      return <Repeat className="w-4 h-4" />;
+    case "gas":
+      return <Fuel className="w-4 h-4" />;
+    default:
+      return null;
+  }
+};
+
+export default function AllTransactionsTab() {
+  const [params] = useSearchParams();
+  const address = params.get("address") || "";
+
+  // server data
+  const [items, setItems] = useState<TxRow[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // MVP filter: transaction type only
+  const [selectedTypes, setSelectedTypes] = useState<TxType[] | ["all"]>([
+    "all",
+  ] as any);
+
+  const visibleColumnsInit = {
     type: true,
     date: true,
-    description: true,
     network: true,
-    wallet: true,
-    amount: true,
-    usdValue: true,
-    transaction: true,
-  });
+    asset: true,
+    qty: true,
+    usd: true,
+    counterparty: true,
+    tx: true,
+  } as const;
+  const [visibleColumns, setVisibleColumns] = useState<
+    Record<keyof typeof visibleColumnsInit, boolean>
+  >({ ...visibleColumnsInit });
 
-  const transactionTypes = ["income", "swap", "expense"];
-  const networks = ["ethereum", "polygon", "solana", "bsc", "avalanche"];
+  const loadPage = async (append: boolean) => {
+    if (!address) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const qs = new URLSearchParams();
+      qs.set("kind", "all");
+      qs.set("limit", "20");
+      if (append && nextCursor) qs.set("cursor", nextCursor);
 
-  const filteredTransactions = transactions.filter((tx) => {
-    const matchesSearch =
-      tx.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tx.amount.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tx.hash.toLowerCase().includes(searchQuery.toLowerCase());
-
-    const matchesType =
-      selectedTypes.includes("all") || selectedTypes.includes(tx.type);
-    const matchesNetwork =
-      selectedNetworks.includes("all") || selectedNetworks.includes(tx.network);
-    const matchesWallet =
-      selectedWallets.includes("all") || selectedWallets.includes(tx.walletId);
-    const matchesAmount =
-      Math.abs(tx.usdValue) >= amountRange[0] &&
-      Math.abs(tx.usdValue) <= amountRange[1];
-
-    let matchesDate = true;
-    if (dateFrom || dateTo) {
-      const txDate = new Date(tx.date);
-      if (dateFrom && txDate < dateFrom) matchesDate = false;
-      if (dateTo && txDate > dateTo) matchesDate = false;
-    }
-
-    return (
-      matchesSearch &&
-      matchesType &&
-      matchesNetwork &&
-      matchesWallet &&
-      matchesAmount &&
-      matchesDate
-    );
-  });
-
-  const handleTypeChange = (type: string, checked: boolean) => {
-    if (type === "all") {
-      setSelectedTypes(checked ? ["all"] : []);
-    } else {
-      const newTypes = checked
-        ? [...selectedTypes.filter((t) => t !== "all"), type]
-        : selectedTypes.filter((t) => t !== type);
-      setSelectedTypes(newTypes.length === 0 ? ["all"] : newTypes);
+      const res = await fetch(
+        `/api/portfolio/txs/${encodeURIComponent(address)}?${qs}`
+      );
+      if (!res.ok) {
+        let msg = "Failed to load transactions";
+        try {
+          const j = await res.json();
+          msg = j?.error?.message || msg;
+        } catch {}
+        throw new Error(msg);
+      }
+      const data = (await res.json()) as TxFeed;
+      const pageItems = data?.items || [];
+      setItems((prev) => (append ? [...prev, ...pageItems] : pageItems));
+      setNextCursor(data?.page?.nextCursor || null);
+    } catch (e: any) {
+      setError(e?.message || "Failed to load transactions");
+    } finally {
+      setLoading(false);
     }
   };
 
-  const handleNetworkChange = (network: string, checked: boolean) => {
-    if (network === "all") {
-      setSelectedNetworks(checked ? ["all"] : []);
-    } else {
-      const newNetworks = checked
-        ? [...selectedNetworks.filter((n) => n !== "all"), network]
-        : selectedNetworks.filter((n) => n !== network);
-      setSelectedNetworks(newNetworks.length === 0 ? ["all"] : newNetworks);
+  // initial & when address changes or refresh
+  useEffect(() => {
+    setItems([]);
+    setNextCursor(null);
+    if (address) loadPage(false);
+  }, [address, refreshKey]);
+
+  const filtered = useMemo(() => {
+    if (!items?.length) return [] as TxRow[];
+    const types = Array.isArray(selectedTypes) ? selectedTypes : ["all"];
+    if ((types as any)[0] === "all") return items;
+    return items.filter((r) => (types as TxType[]).includes(r.type));
+  }, [items, selectedTypes]);
+
+  const toggleType = (t: TxType | "all", checked: boolean) => {
+    if (t === "all") {
+      setSelectedTypes(checked ? (["all"] as any) : ([] as any));
+      return;
     }
+    setSelectedTypes((prev: any) => {
+      const arr: TxType[] =
+        Array.isArray(prev) && prev[0] !== "all" ? prev : [];
+      const next = checked ? [...arr, t] : arr.filter((x) => x !== t);
+      return next.length ? next : (["all"] as any);
+    });
   };
 
-  const handleWalletChange = (walletId: string, checked: boolean) => {
-    if (walletId === "all") {
-      setSelectedWallets(checked ? ["all"] : []);
-    } else {
-      const newWallets = checked
-        ? [...selectedWallets.filter((w) => w !== "all"), walletId]
-        : selectedWallets.filter((w) => w !== walletId);
-      setSelectedWallets(newWallets.length === 0 ? ["all"] : newWallets);
-    }
-  };
+  const onRefresh = () => setRefreshKey((k) => k + 1);
 
-  const getTransactionColor = (type: string) => {
-    switch (type) {
-      case "income":
-        return "text-green-600";
-      case "expense":
-        return "text-red-600";
-      case "swap":
-        return "text-blue-600";
+  const explorerBase = (network?: string) => {
+    switch (network) {
+      case "eth-mainnet":
+      case "ethereum":
+        return "https://etherscan.io";
+      case "eth-sepolia":
+      case "sepolia":
+        return "https://sepolia.etherscan.io";
       default:
-        return "text-slate-600";
+        return "https://etherscan.io"; // MVP fallback
     }
   };
+  const etherscanTxUrl = (hash: string, network?: string) =>
+    `${explorerBase(network)}/tx/${hash}`;
 
-  const getTransactionIcon = (type: string) => {
-    switch (type) {
-      case "income":
-        return <TrendingUp className="w-4 h-4" />;
-      case "expense":
-        return <TrendingDown className="w-4 h-4" />;
-      case "swap":
-        return <Repeat className="w-4 h-4" />;
+  const networkLabel = (network?: string) => {
+    switch (network) {
+      case "eth-mainnet":
+      case "ethereum":
+        return "Ethereum";
+      case "eth-sepolia":
+      case "sepolia":
+        return "Sepolia";
       default:
-        return <Coins className="w-4 h-4" />;
+        return network || "Unknown";
     }
   };
 
   return (
     <div className="space-y-6">
-      {/* All Transactions Table */}
       <Card className="bg-white shadow-sm">
         <div className="p-6 border-b">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-xl font-bold text-slate-800">
-              All Transactions ({filteredTransactions.length})
+              All Transactions {address ? "" : "(load an address)"}
             </h3>
             <div className="flex items-center gap-2">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" size="sm">
-                    <Eye className="w-4 h-4 mr-2" />
-                    Columns
+                    <Eye className="w-4 h-4 mr-2" /> Columns
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-48">
-                  {Object.entries(visibleColumns).map(([key, visible]) => (
+                  {(
+                    Object.keys(visibleColumns) as Array<
+                      keyof typeof visibleColumnsInit
+                    >
+                  ).map((key) => (
                     <DropdownMenuCheckboxItem
                       key={key}
-                      checked={visible}
+                      checked={visibleColumns[key]}
                       onCheckedChange={(checked) =>
                         setVisibleColumns((prev) => ({
                           ...prev,
@@ -210,351 +257,198 @@ const AllTransactionsTab = ({
                         }))
                       }
                     >
-                      {key.charAt(0).toUpperCase() + key.slice(1)}
+                      {String(key).charAt(0).toUpperCase() +
+                        String(key).slice(1)}
                     </DropdownMenuCheckboxItem>
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Button variant="outline" size="sm">
-                <Filter className="w-4 h-4 mr-2" />
-                Export
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRefresh}
+                disabled={loading}
+              >
+                <RefreshCw
+                  className={`w-4 h-4 mr-2 ${loading ? "animate-spin" : ""}`}
+                />
+                Refresh
               </Button>
             </div>
           </div>
 
-          {/* Search and Filters */}
-          <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
-            <div className="flex-1 max-w-md">
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 w-4 h-4" />
-                <Input
-                  placeholder="Search transactions..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pl-10"
-                />
-              </div>
+          {/* MVP Filter: Transaction Type only */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="type-all"
+                checked={(selectedTypes as any)[0] === "all"}
+                onCheckedChange={(c) => toggleType("all", !!c)}
+              />
+              <Label htmlFor="type-all" className="text-sm font-normal">
+                All Types
+              </Label>
             </div>
+
+            {["income", "expense", "swap", "gas"].map((t) => (
+              <div key={t} className="flex items-center space-x-2">
+                <Checkbox
+                  id={`type-${t}`}
+                  checked={
+                    Array.isArray(selectedTypes) &&
+                    (selectedTypes as any)[0] !== "all"
+                      ? (selectedTypes as TxType[]).includes(t as TxType)
+                      : false
+                  }
+                  onCheckedChange={(c) => toggleType(t as TxType, !!c)}
+                />
+                <Label
+                  htmlFor={`type-${t}`}
+                  className="text-sm font-normal capitalize flex items-center gap-1"
+                >
+                  {typeIcon(t as TxType)} {t}
+                </Label>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Status messages */}
+        {!address && (
+          <div className="p-6 text-sm text-slate-500">
+            Enter an address on the Overview tab to load transactions.
+          </div>
+        )}
+        {address && loading && items.length === 0 && (
+          <div className="p-6 text-sm text-slate-500">
+            Loading transactions…
+          </div>
+        )}
+        {address && error && (
+          <div className="p-6 text-sm text-red-600">{error}</div>
+        )}
+
+        {/* Table */}
+        {address && items.length > 0 && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.type && <TableHead>Type</TableHead>}
+                  {visibleColumns.date && <TableHead>Date</TableHead>}
+                  {visibleColumns.network && <TableHead>Network</TableHead>}
+                  {visibleColumns.asset && <TableHead>Asset</TableHead>}
+                  {visibleColumns.qty && <TableHead>Qty</TableHead>}
+                  {visibleColumns.usd && <TableHead>USD @ time</TableHead>}
+                  {visibleColumns.counterparty && (
+                    <TableHead>Counterparty</TableHead>
+                  )}
+                  {visibleColumns.tx && <TableHead>Tx</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((tx, idx) => (
+                  <TableRow key={`${tx.hash}-${idx}`}>
+                    {visibleColumns.type && (
+                      <TableCell>
+                        <div
+                          className={`flex items-center gap-2 ${typeColor(
+                            tx.type
+                          )}`}
+                        >
+                          {typeIcon(tx.type)}
+                          <span className="capitalize text-xs font-medium">
+                            {tx.type}
+                          </span>
+                        </div>
+                      </TableCell>
+                    )}
+                    {visibleColumns.date && (
+                      <TableCell className="font-medium">
+                        {new Date(tx.ts).toLocaleString()}
+                      </TableCell>
+                    )}
+                    {visibleColumns.network && (
+                      <TableCell className="font-mono">
+                        {networkLabel(tx.network)}
+                      </TableCell>
+                    )}
+                    {visibleColumns.asset && (
+                      <TableCell className="font-mono">
+                        {tx.asset?.symbol ||
+                          (tx.asset?.contract
+                            ? shortAddr(tx.asset.contract)
+                            : "—")}
+                      </TableCell>
+                    )}
+                    {visibleColumns.qty && (
+                      <TableCell
+                        className={`font-mono ${
+                          tx.direction === "in"
+                            ? "text-green-600"
+                            : "text-red-600"
+                        }`}
+                      >
+                        {fmtQty(tx.qty, tx.direction)}
+                      </TableCell>
+                    )}
+                    {visibleColumns.usd && (
+                      <TableCell className="font-mono">
+                        {fmtUSD(tx.usdAtTs)}
+                      </TableCell>
+                    )}
+                    {visibleColumns.counterparty && (
+                      <TableCell className="font-mono">
+                        {tx.counterparty?.label ||
+                          shortAddr(tx.counterparty?.address)}
+                      </TableCell>
+                    )}
+                    {visibleColumns.tx && (
+                      <TableCell>
+                        <a
+                          className="inline-flex items-center gap-1 text-xs font-mono underline text-slate-700 hover:text-slate-900"
+                          href={etherscanTxUrl(tx.hash, tx.network)}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {shortAddr(tx.hash)}{" "}
+                          <ExternalLink className="w-3 h-3" />
+                        </a>
+                      </TableCell>
+                    )}
+                  </TableRow>
+                ))}
+
+                {filtered.length === 0 && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={
+                        Object.values(visibleColumns).filter(Boolean).length
+                      }
+                      className="text-center py-8 text-slate-500"
+                    >
+                      No transactions found for the selected type(s).
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {address && (nextCursor || loading) && (
+          <div className="p-4 flex justify-center">
             <Button
+              onClick={() => loadPage(true)}
+              disabled={loading || !nextCursor}
               variant="outline"
-              onClick={() => setIsFiltersOpen(!isFiltersOpen)}
-              className="flex items-center gap-2"
             >
-              <Filter className="w-4 h-4" />
-              Filters
-              {(selectedTypes.length > 1 ||
-                !selectedTypes.includes("all") ||
-                selectedNetworks.length > 1 ||
-                !selectedNetworks.includes("all") ||
-                selectedWallets.length > 1 ||
-                !selectedWallets.includes("all") ||
-                dateFrom ||
-                dateTo) && (
-                <Badge variant="secondary" className="ml-1 text-xs">
-                  Active
-                </Badge>
-              )}
+              {loading ? "Loading…" : nextCursor ? "Load more" : "No more"}
             </Button>
           </div>
-
-          <Collapsible open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
-            <CollapsibleContent className="space-y-6">
-              <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-6 pt-4 border-t">
-                {/* Transaction Types */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">
-                    Transaction Types
-                  </Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="type-all"
-                        checked={selectedTypes.includes("all")}
-                        onCheckedChange={(checked) =>
-                          handleTypeChange("all", !!checked)
-                        }
-                      />
-                      <Label htmlFor="type-all" className="text-sm font-normal">
-                        All Types
-                      </Label>
-                    </div>
-                    {transactionTypes.map((type) => (
-                      <div key={type} className="flex items-center space-x-2">
-                        <Checkbox
-                          id={`type-${type}`}
-                          checked={selectedTypes.includes(type)}
-                          onCheckedChange={(checked) =>
-                            handleTypeChange(type, !!checked)
-                          }
-                        />
-                        <Label
-                          htmlFor={`type-${type}`}
-                          className="text-sm font-normal capitalize flex items-center gap-1"
-                        >
-                          {getTransactionIcon(type)}
-                          {type}
-                        </Label>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Networks */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Networks</Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="network-all"
-                        checked={selectedNetworks.includes("all")}
-                        onCheckedChange={(checked) =>
-                          handleNetworkChange("all", !!checked)
-                        }
-                      />
-                      <Label
-                        htmlFor="network-all"
-                        className="text-sm font-normal"
-                      >
-                        All Networks
-                      </Label>
-                    </div>
-                    {networks.map((network) => (
-                      <div
-                        key={network}
-                        className="flex items-center space-x-2"
-                      >
-                        <Checkbox
-                          id={`network-${network}`}
-                          checked={selectedNetworks.includes(network)}
-                          onCheckedChange={(checked) =>
-                            handleNetworkChange(network, !!checked)
-                          }
-                        />
-                        <Label
-                          htmlFor={`network-${network}`}
-                          className="text-sm font-normal capitalize"
-                        >
-                          {network}
-                        </Label>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Wallets */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Wallets</Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="wallet-all"
-                        checked={selectedWallets.includes("all")}
-                        onCheckedChange={(checked) =>
-                          handleWalletChange("all", !!checked)
-                        }
-                      />
-                      <Label
-                        htmlFor="wallet-all"
-                        className="text-sm font-normal"
-                      >
-                        All Wallets
-                      </Label>
-                    </div>
-                    {connectedWallets.map((wallet) => (
-                      <div
-                        key={wallet.id}
-                        className="flex items-center space-x-2"
-                      >
-                        <Checkbox
-                          id={`wallet-${wallet.id}`}
-                          checked={selectedWallets.includes(wallet.id)}
-                          onCheckedChange={(checked) =>
-                            handleWalletChange(wallet.id, !!checked)
-                          }
-                        />
-                        <Label
-                          htmlFor={`wallet-${wallet.id}`}
-                          className="text-sm font-normal"
-                        >
-                          {wallet.name}
-                        </Label>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Amount Range */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">
-                    Amount Range (USD)
-                  </Label>
-                  <div className="space-y-2">
-                    <Slider
-                      value={amountRange}
-                      onValueChange={setAmountRange}
-                      max={50000}
-                      min={0}
-                      step={100}
-                      className="w-full"
-                    />
-                    <div className="flex justify-between text-xs text-slate-500">
-                      <span>${amountRange[0].toLocaleString()}</span>
-                      <span>${amountRange[1].toLocaleString()}</span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Date Range */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium">Date Range</Label>
-                  <div className="flex gap-2">
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="flex-1 justify-start text-left font-normal"
-                        >
-                          <Calendar className="mr-2 h-4 w-4" />
-                          {dateFrom ? format(dateFrom, "MMM dd") : "From"}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0" align="start">
-                        <CalendarComponent
-                          mode="single"
-                          selected={dateFrom}
-                          onSelect={setDateFrom}
-                          initialFocus
-                        />
-                      </PopoverContent>
-                    </Popover>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="flex-1 justify-start text-left font-normal"
-                        >
-                          <Calendar className="mr-2 h-4 w-4" />
-                          {dateTo ? format(dateTo, "MMM dd") : "To"}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0" align="start">
-                        <CalendarComponent
-                          mode="single"
-                          selected={dateTo}
-                          onSelect={setDateTo}
-                          initialFocus
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                </div>
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        </div>
-
-        <div className="overflow-x-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                {visibleColumns.type && <TableHead>Type</TableHead>}
-                {visibleColumns.date && <TableHead>Date</TableHead>}
-                {visibleColumns.description && (
-                  <TableHead>Description</TableHead>
-                )}
-                {visibleColumns.network && <TableHead>Network</TableHead>}
-                {visibleColumns.wallet && <TableHead>Wallet</TableHead>}
-                {visibleColumns.amount && <TableHead>Amount</TableHead>}
-                {visibleColumns.usdValue && <TableHead>USD Value</TableHead>}
-                {visibleColumns.transaction && (
-                  <TableHead>Transaction</TableHead>
-                )}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredTransactions.map((tx) => (
-                <TableRow key={tx.id}>
-                  {visibleColumns.type && (
-                    <TableCell>
-                      <div
-                        className={`flex items-center gap-2 ${getTransactionColor(
-                          tx.type
-                        )}`}
-                      >
-                        {getTransactionIcon(tx.type)}
-                        <span className="capitalize text-xs font-medium">
-                          {tx.type}
-                        </span>
-                      </div>
-                    </TableCell>
-                  )}
-                  {visibleColumns.date && (
-                    <TableCell className="font-medium">{tx.date}</TableCell>
-                  )}
-                  {visibleColumns.description && (
-                    <TableCell>{tx.description}</TableCell>
-                  )}
-                  {visibleColumns.network && (
-                    <TableCell>
-                      <Badge variant="outline" className="capitalize text-xs">
-                        {tx.network}
-                      </Badge>
-                    </TableCell>
-                  )}
-                  {visibleColumns.wallet && (
-                    <TableCell>
-                      <Badge variant="outline" className="text-xs">
-                        {getWalletName(tx.walletId)}
-                      </Badge>
-                    </TableCell>
-                  )}
-                  {visibleColumns.amount && (
-                    <TableCell
-                      className={`font-mono ${getTransactionColor(tx.type)}`}
-                    >
-                      {tx.amount}
-                    </TableCell>
-                  )}
-                  {visibleColumns.usdValue && (
-                    <TableCell
-                      className={`font-mono ${getTransactionColor(tx.type)}`}
-                    >
-                      {tx.usdValue === 0
-                        ? "$0.00"
-                        : tx.usdValue > 0
-                        ? `+$${tx.usdValue.toFixed(2)}`
-                        : `-$${Math.abs(tx.usdValue).toFixed(2)}`}
-                    </TableCell>
-                  )}
-                  {visibleColumns.transaction && (
-                    <TableCell>
-                      <Badge variant="outline" className="font-mono text-xs">
-                        {tx.hash}
-                      </Badge>
-                    </TableCell>
-                  )}
-                </TableRow>
-              ))}
-              {filteredTransactions.length === 0 && (
-                <TableRow>
-                  <TableCell
-                    colSpan={
-                      Object.values(visibleColumns).filter(Boolean).length
-                    }
-                    className="text-center py-8 text-slate-500"
-                  >
-                    No transactions found matching your filters.
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
+        )}
       </Card>
     </div>
   );
-};
-
-export default AllTransactionsTab;
+}

--- a/frontend/src/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/src/components/dashboard/AllTransactionsTab.tsx
@@ -1,6 +1,14 @@
-
 import { useState } from "react";
-import { TrendingUp, TrendingDown, Repeat, Coins, Filter, Search, Calendar, Eye } from "lucide-react";
+import {
+  TrendingUp,
+  TrendingDown,
+  Repeat,
+  Coins,
+  Filter,
+  Search,
+  Calendar,
+  Eye,
+} from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -9,10 +17,26 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Calendar as CalendarComponent } from "@/components/ui/calendar";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, DropdownMenuCheckboxItem } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu";
 import { format } from "date-fns";
 
 interface Transaction {
@@ -29,11 +53,20 @@ interface Transaction {
 
 interface AllTransactionsTabProps {
   transactions: Transaction[];
-  connectedWallets: Array<{ id: string; name: string; address: string; network: string }>;
+  connectedWallets: Array<{
+    id: string;
+    name: string;
+    address: string;
+    network: string;
+  }>;
   getWalletName: (walletId: string) => string;
 }
 
-const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: AllTransactionsTabProps) => {
+const AllTransactionsTab = ({
+  transactions,
+  connectedWallets,
+  getWalletName,
+}: AllTransactionsTabProps) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>(["all"]);
   const [selectedNetworks, setSelectedNetworks] = useState<string[]>(["all"]);
@@ -50,39 +83,52 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
     wallet: true,
     amount: true,
     usdValue: true,
-    transaction: true
+    transaction: true,
   });
 
   const transactionTypes = ["income", "swap", "expense"];
   const networks = ["ethereum", "polygon", "solana", "bsc", "avalanche"];
 
-  const filteredTransactions = transactions.filter(tx => {
-    const matchesSearch = tx.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         tx.amount.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         tx.hash.toLowerCase().includes(searchQuery.toLowerCase());
-    
-    const matchesType = selectedTypes.includes("all") || selectedTypes.includes(tx.type);
-    const matchesNetwork = selectedNetworks.includes("all") || selectedNetworks.includes(tx.network);
-    const matchesWallet = selectedWallets.includes("all") || selectedWallets.includes(tx.walletId);
-    const matchesAmount = Math.abs(tx.usdValue) >= amountRange[0] && Math.abs(tx.usdValue) <= amountRange[1];
-    
+  const filteredTransactions = transactions.filter((tx) => {
+    const matchesSearch =
+      tx.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      tx.amount.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      tx.hash.toLowerCase().includes(searchQuery.toLowerCase());
+
+    const matchesType =
+      selectedTypes.includes("all") || selectedTypes.includes(tx.type);
+    const matchesNetwork =
+      selectedNetworks.includes("all") || selectedNetworks.includes(tx.network);
+    const matchesWallet =
+      selectedWallets.includes("all") || selectedWallets.includes(tx.walletId);
+    const matchesAmount =
+      Math.abs(tx.usdValue) >= amountRange[0] &&
+      Math.abs(tx.usdValue) <= amountRange[1];
+
     let matchesDate = true;
     if (dateFrom || dateTo) {
       const txDate = new Date(tx.date);
       if (dateFrom && txDate < dateFrom) matchesDate = false;
       if (dateTo && txDate > dateTo) matchesDate = false;
     }
-    
-    return matchesSearch && matchesType && matchesNetwork && matchesWallet && matchesAmount && matchesDate;
+
+    return (
+      matchesSearch &&
+      matchesType &&
+      matchesNetwork &&
+      matchesWallet &&
+      matchesAmount &&
+      matchesDate
+    );
   });
 
   const handleTypeChange = (type: string, checked: boolean) => {
     if (type === "all") {
       setSelectedTypes(checked ? ["all"] : []);
     } else {
-      const newTypes = checked 
-        ? [...selectedTypes.filter(t => t !== "all"), type]
-        : selectedTypes.filter(t => t !== type);
+      const newTypes = checked
+        ? [...selectedTypes.filter((t) => t !== "all"), type]
+        : selectedTypes.filter((t) => t !== type);
       setSelectedTypes(newTypes.length === 0 ? ["all"] : newTypes);
     }
   };
@@ -91,9 +137,9 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
     if (network === "all") {
       setSelectedNetworks(checked ? ["all"] : []);
     } else {
-      const newNetworks = checked 
-        ? [...selectedNetworks.filter(n => n !== "all"), network]
-        : selectedNetworks.filter(n => n !== network);
+      const newNetworks = checked
+        ? [...selectedNetworks.filter((n) => n !== "all"), network]
+        : selectedNetworks.filter((n) => n !== network);
       setSelectedNetworks(newNetworks.length === 0 ? ["all"] : newNetworks);
     }
   };
@@ -102,28 +148,36 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
     if (walletId === "all") {
       setSelectedWallets(checked ? ["all"] : []);
     } else {
-      const newWallets = checked 
-        ? [...selectedWallets.filter(w => w !== "all"), walletId]
-        : selectedWallets.filter(w => w !== walletId);
+      const newWallets = checked
+        ? [...selectedWallets.filter((w) => w !== "all"), walletId]
+        : selectedWallets.filter((w) => w !== walletId);
       setSelectedWallets(newWallets.length === 0 ? ["all"] : newWallets);
     }
   };
 
   const getTransactionColor = (type: string) => {
     switch (type) {
-      case "income": return "text-green-600";
-      case "expense": return "text-red-600";
-      case "swap": return "text-blue-600";
-      default: return "text-slate-600";
+      case "income":
+        return "text-green-600";
+      case "expense":
+        return "text-red-600";
+      case "swap":
+        return "text-blue-600";
+      default:
+        return "text-slate-600";
     }
   };
 
   const getTransactionIcon = (type: string) => {
     switch (type) {
-      case "income": return <TrendingUp className="w-4 h-4" />;
-      case "expense": return <TrendingDown className="w-4 h-4" />;
-      case "swap": return <Repeat className="w-4 h-4" />;
-      default: return <Coins className="w-4 h-4" />;
+      case "income":
+        return <TrendingUp className="w-4 h-4" />;
+      case "expense":
+        return <TrendingDown className="w-4 h-4" />;
+      case "swap":
+        return <Repeat className="w-4 h-4" />;
+      default:
+        return <Coins className="w-4 h-4" />;
     }
   };
 
@@ -149,7 +203,12 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                     <DropdownMenuCheckboxItem
                       key={key}
                       checked={visible}
-                      onCheckedChange={(checked) => setVisibleColumns(prev => ({ ...prev, [key]: !!checked }))}
+                      onCheckedChange={(checked) =>
+                        setVisibleColumns((prev) => ({
+                          ...prev,
+                          [key]: !!checked,
+                        }))
+                      }
                     >
                       {key.charAt(0).toUpperCase() + key.slice(1)}
                     </DropdownMenuCheckboxItem>
@@ -183,10 +242,14 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
             >
               <Filter className="w-4 h-4" />
               Filters
-              {(selectedTypes.length > 1 || !selectedTypes.includes("all") || 
-                selectedNetworks.length > 1 || !selectedNetworks.includes("all") ||
-                selectedWallets.length > 1 || !selectedWallets.includes("all") ||
-                dateFrom || dateTo) && (
+              {(selectedTypes.length > 1 ||
+                !selectedTypes.includes("all") ||
+                selectedNetworks.length > 1 ||
+                !selectedNetworks.includes("all") ||
+                selectedWallets.length > 1 ||
+                !selectedWallets.includes("all") ||
+                dateFrom ||
+                dateTo) && (
                 <Badge variant="secondary" className="ml-1 text-xs">
                   Active
                 </Badge>
@@ -199,24 +262,35 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
               <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-6 pt-4 border-t">
                 {/* Transaction Types */}
                 <div className="space-y-3">
-                  <Label className="text-sm font-medium">Transaction Types</Label>
+                  <Label className="text-sm font-medium">
+                    Transaction Types
+                  </Label>
                   <div className="space-y-2">
                     <div className="flex items-center space-x-2">
                       <Checkbox
                         id="type-all"
                         checked={selectedTypes.includes("all")}
-                        onCheckedChange={(checked) => handleTypeChange("all", !!checked)}
+                        onCheckedChange={(checked) =>
+                          handleTypeChange("all", !!checked)
+                        }
                       />
-                      <Label htmlFor="type-all" className="text-sm font-normal">All Types</Label>
+                      <Label htmlFor="type-all" className="text-sm font-normal">
+                        All Types
+                      </Label>
                     </div>
                     {transactionTypes.map((type) => (
                       <div key={type} className="flex items-center space-x-2">
                         <Checkbox
                           id={`type-${type}`}
                           checked={selectedTypes.includes(type)}
-                          onCheckedChange={(checked) => handleTypeChange(type, !!checked)}
+                          onCheckedChange={(checked) =>
+                            handleTypeChange(type, !!checked)
+                          }
                         />
-                        <Label htmlFor={`type-${type}`} className="text-sm font-normal capitalize flex items-center gap-1">
+                        <Label
+                          htmlFor={`type-${type}`}
+                          className="text-sm font-normal capitalize flex items-center gap-1"
+                        >
                           {getTransactionIcon(type)}
                           {type}
                         </Label>
@@ -233,18 +307,33 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                       <Checkbox
                         id="network-all"
                         checked={selectedNetworks.includes("all")}
-                        onCheckedChange={(checked) => handleNetworkChange("all", !!checked)}
+                        onCheckedChange={(checked) =>
+                          handleNetworkChange("all", !!checked)
+                        }
                       />
-                      <Label htmlFor="network-all" className="text-sm font-normal">All Networks</Label>
+                      <Label
+                        htmlFor="network-all"
+                        className="text-sm font-normal"
+                      >
+                        All Networks
+                      </Label>
                     </div>
                     {networks.map((network) => (
-                      <div key={network} className="flex items-center space-x-2">
+                      <div
+                        key={network}
+                        className="flex items-center space-x-2"
+                      >
                         <Checkbox
                           id={`network-${network}`}
                           checked={selectedNetworks.includes(network)}
-                          onCheckedChange={(checked) => handleNetworkChange(network, !!checked)}
+                          onCheckedChange={(checked) =>
+                            handleNetworkChange(network, !!checked)
+                          }
                         />
-                        <Label htmlFor={`network-${network}`} className="text-sm font-normal capitalize">
+                        <Label
+                          htmlFor={`network-${network}`}
+                          className="text-sm font-normal capitalize"
+                        >
                           {network}
                         </Label>
                       </div>
@@ -260,18 +349,33 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                       <Checkbox
                         id="wallet-all"
                         checked={selectedWallets.includes("all")}
-                        onCheckedChange={(checked) => handleWalletChange("all", !!checked)}
+                        onCheckedChange={(checked) =>
+                          handleWalletChange("all", !!checked)
+                        }
                       />
-                      <Label htmlFor="wallet-all" className="text-sm font-normal">All Wallets</Label>
+                      <Label
+                        htmlFor="wallet-all"
+                        className="text-sm font-normal"
+                      >
+                        All Wallets
+                      </Label>
                     </div>
                     {connectedWallets.map((wallet) => (
-                      <div key={wallet.id} className="flex items-center space-x-2">
+                      <div
+                        key={wallet.id}
+                        className="flex items-center space-x-2"
+                      >
                         <Checkbox
                           id={`wallet-${wallet.id}`}
                           checked={selectedWallets.includes(wallet.id)}
-                          onCheckedChange={(checked) => handleWalletChange(wallet.id, !!checked)}
+                          onCheckedChange={(checked) =>
+                            handleWalletChange(wallet.id, !!checked)
+                          }
                         />
-                        <Label htmlFor={`wallet-${wallet.id}`} className="text-sm font-normal">
+                        <Label
+                          htmlFor={`wallet-${wallet.id}`}
+                          className="text-sm font-normal"
+                        >
                           {wallet.name}
                         </Label>
                       </div>
@@ -281,7 +385,9 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
 
                 {/* Amount Range */}
                 <div className="space-y-3">
-                  <Label className="text-sm font-medium">Amount Range (USD)</Label>
+                  <Label className="text-sm font-medium">
+                    Amount Range (USD)
+                  </Label>
                   <div className="space-y-2">
                     <Slider
                       value={amountRange}
@@ -304,7 +410,11 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                   <div className="flex gap-2">
                     <Popover>
                       <PopoverTrigger asChild>
-                        <Button variant="outline" size="sm" className="flex-1 justify-start text-left font-normal">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex-1 justify-start text-left font-normal"
+                        >
                           <Calendar className="mr-2 h-4 w-4" />
                           {dateFrom ? format(dateFrom, "MMM dd") : "From"}
                         </Button>
@@ -320,7 +430,11 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                     </Popover>
                     <Popover>
                       <PopoverTrigger asChild>
-                        <Button variant="outline" size="sm" className="flex-1 justify-start text-left font-normal">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="flex-1 justify-start text-left font-normal"
+                        >
                           <Calendar className="mr-2 h-4 w-4" />
                           {dateTo ? format(dateTo, "MMM dd") : "To"}
                         </Button>
@@ -347,12 +461,16 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
               <TableRow>
                 {visibleColumns.type && <TableHead>Type</TableHead>}
                 {visibleColumns.date && <TableHead>Date</TableHead>}
-                {visibleColumns.description && <TableHead>Description</TableHead>}
+                {visibleColumns.description && (
+                  <TableHead>Description</TableHead>
+                )}
                 {visibleColumns.network && <TableHead>Network</TableHead>}
                 {visibleColumns.wallet && <TableHead>Wallet</TableHead>}
                 {visibleColumns.amount && <TableHead>Amount</TableHead>}
                 {visibleColumns.usdValue && <TableHead>USD Value</TableHead>}
-                {visibleColumns.transaction && <TableHead>Transaction</TableHead>}
+                {visibleColumns.transaction && (
+                  <TableHead>Transaction</TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -360,14 +478,24 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                 <TableRow key={tx.id}>
                   {visibleColumns.type && (
                     <TableCell>
-                      <div className={`flex items-center gap-2 ${getTransactionColor(tx.type)}`}>
+                      <div
+                        className={`flex items-center gap-2 ${getTransactionColor(
+                          tx.type
+                        )}`}
+                      >
                         {getTransactionIcon(tx.type)}
-                        <span className="capitalize text-xs font-medium">{tx.type}</span>
+                        <span className="capitalize text-xs font-medium">
+                          {tx.type}
+                        </span>
                       </div>
                     </TableCell>
                   )}
-                  {visibleColumns.date && <TableCell className="font-medium">{tx.date}</TableCell>}
-                  {visibleColumns.description && <TableCell>{tx.description}</TableCell>}
+                  {visibleColumns.date && (
+                    <TableCell className="font-medium">{tx.date}</TableCell>
+                  )}
+                  {visibleColumns.description && (
+                    <TableCell>{tx.description}</TableCell>
+                  )}
                   {visibleColumns.network && (
                     <TableCell>
                       <Badge variant="outline" className="capitalize text-xs">
@@ -383,15 +511,21 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
                     </TableCell>
                   )}
                   {visibleColumns.amount && (
-                    <TableCell className={`font-mono ${getTransactionColor(tx.type)}`}>
+                    <TableCell
+                      className={`font-mono ${getTransactionColor(tx.type)}`}
+                    >
                       {tx.amount}
                     </TableCell>
                   )}
                   {visibleColumns.usdValue && (
-                    <TableCell className={`font-mono ${getTransactionColor(tx.type)}`}>
-                      {tx.usdValue === 0 ? "$0.00" : 
-                       tx.usdValue > 0 ? `+$${tx.usdValue.toFixed(2)}` : 
-                       `-$${Math.abs(tx.usdValue).toFixed(2)}`}
+                    <TableCell
+                      className={`font-mono ${getTransactionColor(tx.type)}`}
+                    >
+                      {tx.usdValue === 0
+                        ? "$0.00"
+                        : tx.usdValue > 0
+                        ? `+$${tx.usdValue.toFixed(2)}`
+                        : `-$${Math.abs(tx.usdValue).toFixed(2)}`}
                     </TableCell>
                   )}
                   {visibleColumns.transaction && (
@@ -405,7 +539,12 @@ const AllTransactionsTab = ({ transactions, connectedWallets, getWalletName }: A
               ))}
               {filteredTransactions.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={Object.values(visibleColumns).filter(Boolean).length} className="text-center py-8 text-slate-500">
+                  <TableCell
+                    colSpan={
+                      Object.values(visibleColumns).filter(Boolean).length
+                    }
+                    className="text-center py-8 text-slate-500"
+                  >
                     No transactions found matching your filters.
                   </TableCell>
                 </TableRow>

--- a/frontend/src/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/src/components/dashboard/AllTransactionsTab.tsx
@@ -487,19 +487,6 @@ export default function AllTransactionsTab() {
             </Table>
           </div>
         )}
-
-        {/* Pagination */}
-        {address && (nextCursor || loading) && (
-          <div className="p-4 flex justify-center">
-            <Button
-              onClick={() => loadPage(true)}
-              disabled={loading || !nextCursor}
-              variant="outline"
-            >
-              {loading ? "Loading…" : nextCursor ? "Load more" : "No more"}
-            </Button>
-          </div>
-        )}
       </Card>
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -398,6 +398,10 @@ const Dashboard = () => {
                 </div>
               </Card>
 
+              {/* 
+              
+              TO DO : Metrics below require real data, so hiding for now, do after the MVP (demo) is done
+
               <Card className="p-6 bg-white shadow-sm">
                 <div className="flex items-center justify-between">
                   <div>
@@ -428,12 +432,12 @@ const Dashboard = () => {
                   </div>
                   <DollarSign className="w-12 h-12 text-orange-500" />
                 </div>
-              </Card>
+              </Card> */}
             </div>
 
             {/* Charts */}
             <div className="grid lg:grid-cols-2 gap-6">
-              <Card className="p-6 bg-white shadow-sm">
+              {/* <Card className="p-6 bg-white shadow-sm">
                 <h3 className="text-lg font-semibold text-slate-800 mb-4">
                   Portfolio Performance
                 </h3>
@@ -450,7 +454,7 @@ const Dashboard = () => {
                     />
                   </LineChart>
                 </ResponsiveContainer>
-              </Card>
+              </Card> */}
 
               <Card className="p-6 bg-white shadow-sm">
                 <h3 className="text-lg font-semibold text-slate-800 mb-4">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -354,7 +354,7 @@ const Dashboard = () => {
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="income">Income</TabsTrigger>
             <TabsTrigger value="expenses">Expenses</TabsTrigger>
-            <TabsTrigger value="capital-gains">Capital Gains</TabsTrigger>
+            {/* <TabsTrigger value="capital-gains">Capital Gains</TabsTrigger> */}
             <TabsTrigger value="all-transactions">All Transactions</TabsTrigger>
           </TabsList>
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -624,11 +624,7 @@ const Dashboard = () => {
           </TabsContent>
 
           <TabsContent value="all-transactions">
-            <AllTransactionsTab
-              transactions={transactions}
-              connectedWallets={connectedWallets}
-              getWalletName={getWalletName}
-            />
+            <AllTransactionsTab />
           </TabsContent>
         </Tabs>
       </main>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -352,8 +352,8 @@ const Dashboard = () => {
         <Tabs defaultValue="overview" className="space-y-6">
           <TabsList className="grid w-full grid-cols-5">
             <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="income">Income</TabsTrigger>
-            <TabsTrigger value="expenses">Expenses</TabsTrigger>
+            {/* <TabsTrigger value="income">Income</TabsTrigger>
+            <TabsTrigger value="expenses">Expenses</TabsTrigger> */}
             {/* <TabsTrigger value="capital-gains">Capital Gains</TabsTrigger> */}
             <TabsTrigger value="all-transactions">All Transactions</TabsTrigger>
           </TabsList>


### PR DESCRIPTION
# Transactions MVP — Portfolio Feed (Ethereum)

## Summary

This PR introduces the end-to-end **Transactions** functionality for the LedgerLift MVP (Ethereum Mainnet only):

* **Frontend**: Transactions tab wired to backend feed with **Prev/Next paging**, **type filter** (All/Income/Expense/Swap/Gas), **network-aware explorer links**, and a clean table UI.
* **Backend**: `/api/portfolio/txs/:address` endpoint that aggregates external ETH transfers, internal ETH value transfers, and ERC-20 transfers; normalizes rows; **detects swaps**; injects **synthetic gas** rows for outbound hashes; enriches with **USD-at-timestamp** prices; and returns a **cursor-based** page.
* **Parity & Scope**: Ethereum Mainnet only; 20 rows per page; pricing via existing helpers; differences vs Etherscan expected due to heuristics.

This unblocks the product demo by enabling users to view a wallet’s recent activity with meaningful types and USD context.

---

## Goals & Non-Goals

### Goals

* Show a reliable, normalized stream of wallet activity on **Ethereum Mainnet**.
* Support **type classification**: `income`, `expense`, `swap`, and `gas`.
* Provide **cursor-based pagination** so the UI can page beyond 20 items.
* Enrich rows with **USD price at transaction time** (`priceUsdAtTs`, `usdAtTs`).
* Offer a table that’s demo-friendly (network column, explorer link, counterparty).

### Non-Goals (out of scope for this PR)

* Multi-chain support beyond Ethereum.
* Full-history export/streaming from backend.
* Rich contract labeling / spam filtering heuristics.
* Advanced filters (date range, amount range, counterparty search).
* Persisted storage or server-side caching of transaction history.

---

## High-Level Architecture

```
Frontend (React + TS)
  └── /dashboard?address=... → AllTransactionsTab.tsx
       ├─ fetch /api/portfolio/txs/:address?kind=&type=&limit=&cursor=
       ├─ table (Type, Date, Network, Asset, Qty, USD@time, Counterparty, Explorer)
       ├─ “Latest X–Y” counter with Prev/Next
       └─ Type filter (All/Income/Expense/Swap/Gas)

Backend (Express + TS)
  routes/txs.routes.ts
    └─ GET /api/portfolio/txs/:address → services/txs.service.ts
         ├─ pull external ETH, internal ETH, ERC-20 via Alchemy
         ├─ normalize → TxRow[]
         ├─ classify swaps (hash-level, ERC-20 in+out)
         ├─ add synthetic gas rows (for outbound hashes)
         ├─ enrich price @ timestamp (ETH + ERC-20)
         └─ return TxFeed (items + page.nextCursor)
```

---

## Key Files

### Frontend

* `src/components/dashboard/AllTransactionsTab.tsx`
  Transactions UI: fetch, paging, type filter, table rendering, explorer links.

*(The canvas “Ledger Lift — Wire All Transactions Tab To Backend (step 1)” reflects the latest state.)*

### Backend

* `routes/txs.routes.ts`
  Express route: validates query, forwards `address`, `kind`, `type`, `cursor`, `limit` to service, returns `TxFeed`.
* `services/txs.service.ts`
  Business logic: aggregation, normalization, classification (swap/gas), price enrichment, pagination cursor.
* `utils/alchemy.ts`
  Alchemy client and low-level helpers.
* `utils/prices.ts`
  ETH and ERC-20 **price at timestamp** helpers (DeFiLlama + DexScreener fallback).

---

## API — Endpoint & Parameters

### `GET /api/portfolio/txs/:address`

**Query params**

* `kind` — `all | transactions | tokens` (default `all`)

  * `transactions`: ETH external + internal only
  * `tokens`: ERC-20 only
  * `all`: union of the above
* `type` — `income | expense | swap | gas` (optional server filter)
* `limit` — page size (default `20`, min `1`, max `100`)
* `cursor` — opaque Base64 cursor returned by prior call (optional)

**Response: `TxFeed`**

```json
{
  "network": "eth-mainnet",
  "wallet": { "input": "vitalik.eth", "address": "0xd8da...", "ens": null },
  "window": { "from": null, "to": null },
  "page": { "limit": 20, "cursor": null, "nextCursor": "BASE64...", "total": null },
  "items": [
    {
      "ts": "2024-12-01T12:34:56Z",
      "blockNumber": 19283746,
      "hash": "0x...",
      "network": "eth-mainnet",
      "direction": "in",
      "type": "income",
      "asset": { "symbol": "ETH", "contract": null, "decimals": 18 },
      "qty": "0.5",
      "priceUsdAtTs": 2034.12,
      "usdAtTs": 1017.06,
      "counterparty": { "address": "0xabc...", "label": null },
      "fee": null,
      "isApprox": false
    }
  ]
}
```

**Error shape**

```json
{ "ok": false, "error": { "code": "SERVER_ERROR", "message": "..." } }
```

Other possible codes: `BadRequest`, `UpstreamError`.

---

## Classification Rules

* **Direction**

  * ETH ext/internal: `from == wallet ? "out" : "in"`
  * ERC-20: `from == wallet ? "out" : "in"`
* **Type**

  * `income` / `expense`: standalone transfer by direction
  * `swap`: **same tx hash** has ≥1 ERC-20 **in** and ≥1 ERC-20 **out**
  * `gas`: synthetic row for each **outbound** hash (effectiveGasPrice × gasUsed)
* **Pricing**

  * ETH: `getEthUsdAt(ts)`
  * ERC-20: `getErc20UsdAt([contracts], ts)` with DexScreener fallback in utils
  * When price missing: `priceUsdAtTs = null`, `usdAtTs = null`

---

## Frontend Behavior

* **Address source**: `dashboard?address=...` (ENS supported by backend).
* **Table columns**: Type, Date, Network, Asset, Qty (signed by direction), USD @ time, Counterparty, Explorer.
* **Filters**: Type chips (All/Income/Expense/Swap/Gas).
  (For MVP, filtering on the server is supported when a single type is selected; otherwise the UI filters client-side.)
* **Pagination**:

  * “Latest X–Y” header with **Prev/Next**.
  * Uses `page.nextCursor` to fetch additional pages when advancing beyond what’s already loaded.
  * Stable order: `blockNumber desc`, then `ts desc`.

---

## How to Test (Manual)

### Local dev

```bash
docker compose --profile dev up --build
# Backend on :8080, FE on :5173 (Vite), proxy /api → backend
```

### Health

```powershell
iwr "http://localhost:8080/api/health" | Select-Object -ExpandProperty Content
```

### Holdings / Overview (sanity)

```powershell
iwr "http://localhost:8080/api/portfolio/holdings/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" | Select-Object -ExpandProperty Content
iwr "http://localhost:8080/api/portfolio/overview/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" | Select-Object -ExpandProperty Content
```

### Transactions API (paging)

```powershell
# Page 1
iwr "http://localhost:8080/api/portfolio/txs/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?kind=all&limit=20" | Select-Object -ExpandProperty Content

# Page 2 (paste nextCursor from previous response)
iwr "http://localhost:8080/api/portfolio/txs/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045?kind=all&limit=20&cursor=<BASE64>" | Select-Object -ExpandProperty Content
```

### Frontend UX

1. Navigate to `/dashboard?address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045`.
2. Open **All Transactions** tab.
3. Verify:

   * First page renders 20 items with mixed types (incl. gas for outbound).
   * **Next** advances to 21–40 (fetches if needed). **Prev** returns to 1–20.
   * Type filter **All → Expense → Swap → Gas** updates table and (if single-select) triggers a server fetch with `?type=`.
   * Explorer links open Etherscan for the right network.

---

## Recommended Reviewer Checklist

* [ ] Route forwards `cursor` and `limit` to the service.
* [ ] Service composes **opaque** Base64 `nextCursor` from Alchemy `pageKey`(s).
* [ ] `addGasRows` does **not** hard-slice; page slicing happens **after** adding gas and classifying swaps.
* [ ] Sorting by `blockNumber desc` then `ts desc` is stable.
* [ ] Pricing enrichment happens **on the page slice**.
* [ ] Frontend **Prev/Next** advances the view and triggers fetch only when needed.
* [ ] Type chips exercise server filter when a single type is selected.

---

## Known Limitations / Tradeoffs

* **Totals**: `page.total` is `null` (no full walk). The header shows “Latest X–Y”; “of Z” appears when we later implement cached totals per address+kind+type.
* **Swap detection**: Heuristic (ERC-20 in+out per hash). No PnL calculation or pool labeling.
* **Spam tokens**: Still visible if present; not filtered server-side (future: hide by default unless priced).
* **Approvals**: Excluded (not transfers).
* **Multi-select type filter**: Client-side only; server accepts a single `type`.

---

## Performance Notes

* Over-fetch window in service (`NEED = max(4×limit, 80)`) ensures reliable swap detection before slicing.
* Batch pricing lookups per `(timestamp, contract)` bucket to reduce calls.
* Gas receipt fetch is parallelized with a small cap.

---

## Security / Privacy

* Read-only access; no auth required for public portfolio endpoints (MVP).
  Future: rate limiting per IP, caching and abuse controls.
* ENS resolution occurs server-side; we respond with both `input` and normalized `address`.

---

## Accessibility & i18n

* Table uses semantic elements; type/color not the sole indicator (icons + labels).
* Dates are rendered using local timezone on the client; CSV/JSON exports use **UTC ISO**.

---

## Follow-Ups (Post-MVP)

1. **Totals per filter** (cached) to show “of Z”.
2. **Export buttons** (CSV/JSON) for **Visible** and **Loaded** rows (frontend-only).
3. **Kind chips** (All / Transactions / Tokens) in the UI.
4. Contract labeling (common protocols), spam hiding toggle.
5. Multi-chain support + chain selector and explorer awareness.
6. Date/amount range filters and counterparty search.
7. Streaming server export for full history with background jobs.

---

## How to Rollback

* Revert this PR; the routes are additive and can be disabled by removing `/txs` route or feature flagging the Transactions tab.

---

## Testing Notes / Edge Cases

* **Self-transfer (ERC-20 from=to=wallet)** → mark with `isApprox:true` if we keep, or ignore in totals (current behavior: included as a row with standard direction rule).
* **Very new tokens** without pricing → `priceUsdAtTs=null`, `usdAtTs=null`; the UI renders “—”.
* **Internal ETH only** (no external) still displays correctly.
* **Gas-only outbound tx** (failed tx) still produces a gas row with `qty`.

---

**Ready for review.**
