### PR TITLE
Bug — Fix SyntaxError au premier chargement de l'application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ jspm_packages/
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Local scripts
+*.bat
+*.ps1

--- a/frontend/app/lib/web3auth.ts
+++ b/frontend/app/lib/web3auth.ts
@@ -1,53 +1,62 @@
-import { OpenloginAdapter } from "@web3auth/openlogin-adapter";
-import { EthereumPrivateKeyProvider } from "@web3auth/ethereum-provider";
+/**
+ * Web3Auth configuration with Openlogin adapter
+ * Uses lazy initialization to avoid server-side module loading issues
+ */
 
-// Web3Auth configuration with Openlogin adapter
-const chainConfig = {
-  chainNamespace: "eip155" as const,
-  chainId: "0x1", // Ethereum mainnet
-  rpcTarget: `https://rpc.ankr.com/eth${
-    process.env.NEXT_PUBLIC_ANKR_API_KEY
-      ? `/${process.env.NEXT_PUBLIC_ANKR_API_KEY}`
-      : ""
-  }`,
-  displayName: "Ethereum Mainnet",
-  blockExplorer: "https://etherscan.io",
-  ticker: "ETH",
-  tickerName: "Ethereum",
-};
+export function getWeb3AuthConfig() {
+  // Only run on client side
+  if (typeof window === "undefined") {
+    throw new Error("Web3Auth config should only be initialized on client side");
+  }
 
-// Initialize Ethereum PrivateKey Provider - REQUIRED FOR WALLET CREATION
-const privateKeyProvider = new EthereumPrivateKeyProvider({
-  config: {
-    chainConfig: chainConfig,
-  },
-});
+  const { OpenloginAdapter } = require("@web3auth/openlogin-adapter");
+  const { EthereumPrivateKeyProvider } = require("@web3auth/ethereum-provider");
 
-// Initialize Openlogin adapter with PrivateKey Provider
-const openloginAdapter = new OpenloginAdapter({
-  adapterSettings: {
-    network: "testnet",
-    clientId: process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID!,
-    uxMode: "redirect" as const,
-    redirectUrl:
-      typeof window !== "undefined"
-        ? `${window.location.origin}/auth`
-        : "/auth",
-  },
-  privateKeyProvider: privateKeyProvider,
-});
+  // Web3Auth configuration with Openlogin adapter
+  const chainConfig = {
+    chainNamespace: "eip155" as const,
+    chainId: "0x1", // Ethereum mainnet
+    rpcTarget: `https://rpc.ankr.com/eth${
+      process.env.NEXT_PUBLIC_ANKR_API_KEY
+        ? `/${process.env.NEXT_PUBLIC_ANKR_API_KEY}`
+        : ""
+    }`,
+    displayName: "Ethereum Mainnet",
+    blockExplorer: "https://etherscan.io",
+    ticker: "ETH",
+    tickerName: "Ethereum",
+  };
 
-// Correct Web3Auth configuration with PrivateKey Provider
-export const web3authConfig = {
-  web3AuthOptions: {
-    clientId: process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID!,
-    web3AuthNetwork: "sapphire_devnet" as const,
-    chainConfig: chainConfig,
-    privateKeyProvider: privateKeyProvider, // ← Also add to main config
-    storageType: "session" as const, // Use sessionStorage instead of localStorage - session clears when tab/browser closes
-    mfaSettings: {
-      mfaLevel: 'optional' as const, // Users can enable 2FA if they want
+  // Initialize Ethereum PrivateKey Provider - REQUIRED FOR WALLET CREATION
+  const privateKeyProvider = new EthereumPrivateKeyProvider({
+    config: {
+      chainConfig: chainConfig,
     },
-  },
-  adapters: [openloginAdapter] as any,
-};
+  });
+
+  // Initialize Openlogin adapter with PrivateKey Provider
+  const openloginAdapter = new OpenloginAdapter({
+    adapterSettings: {
+      network: "testnet",
+      clientId: process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID!,
+      uxMode: "redirect" as const,
+      redirectUrl: `${window.location.origin}/auth`,
+    },
+    privateKeyProvider: privateKeyProvider,
+  });
+
+  // Correct Web3Auth configuration with PrivateKey Provider
+  return {
+    web3AuthOptions: {
+      clientId: process.env.NEXT_PUBLIC_WEB3AUTH_CLIENT_ID!,
+      web3AuthNetwork: "sapphire_devnet" as const,
+      chainConfig: chainConfig,
+      privateKeyProvider: privateKeyProvider,
+      storageType: "session" as const,
+      mfaSettings: {
+        mfaLevel: 'optional' as const,
+      },
+    },
+    adapters: [openloginAdapter] as any,
+  };
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   webpack: (config) => {
+    const path = require("path");
     config.resolve.fallback = {
       ...config.resolve.fallback,
       fs: false,
@@ -15,8 +16,8 @@ const nextConfig = {
       assert: false,
       os: false,
       path: false,
-      buffer: require.resolve("buffer"),
-      process: require.resolve("process/browser"),
+      buffer: path.join(process.cwd(), "node_modules", "buffer", "index.js"),
+      process: path.join(process.cwd(), "node_modules", "process", "browser.js"),
       // Add fallbacks for packages that are not needed in browser
       "@react-native-async-storage/async-storage": false,
       "pino-pretty": false,


### PR DESCRIPTION
## 🎯 Summary

Fixes the `SyntaxError: Invalid or unexpected token` error that occurred on the first app load by using dynamic imports for Web3Auth components.

## 📋 Type of Change

- [x] 🐛 Bug fix

## 📝 Description

### ❌ Problem

On the first app load, a `SyntaxError: Invalid or unexpected token` error appeared in `layout.js`, preventing the app from loading correctly. Manually refreshing the page allowed users to bypass the error.

**Impact**: Users couldn't access the application on first load. This represented a major UX issue, especially in a production Docker context where users don't expect to need to refresh the page.

---

### ✅ Solution

The solution involves using dynamic imports to prevent Next.js from bundling incompatible Node.js modules (like `readable-stream`) into the client bundle during SSR.

The solution implements 3 complementary approaches:

#### 1️⃣ **Dynamic Import of Web3AuthProvider**
Using `next/dynamic` with `ssr: false` to load `Web3AuthProvider` only on the client side.

#### 2️⃣ **Dynamic Import of WalletProvider**
- Load `WalletProvider` dynamically to avoid static import of `WalletContext.tsx`
- Avoid cascade import of `useWeb3Auth` which was loading `readable-stream`

#### 3️⃣ **Lazy Initialization of Web3Auth Config**
Refactoring `web3auth.ts` to use a `getWeb3AuthConfig()` function called only on the client side with dynamic `require()` calls.

---

### 🔧 Technical Changes

#### 📁 Modified Files

| File | Changes |
|------|---------|
| `frontend/app/lib/web3auth.ts` | Refactored to `getWeb3AuthConfig()` function with dynamic `require()` calls |
| `frontend/app/providers.tsx` | Added dynamic imports for `Web3AuthProvider` and `WalletProvider` |
| `frontend/next.config.js` | Changed fallbacks from `require.resolve()` to `path.join()` |

---

#### 🔑 Key Changes

**Before:**
```typescript
import { Web3AuthProvider } from "@web3auth/no-modal-react-hooks";
import { WalletProvider } from "@/contexts/WalletContext";
import { web3authConfig } from "@/lib/web3auth";
```

**After:**
```typescript
const Web3AuthProvider = dynamic(
  () => import("@web3auth/no-modal-react-hooks").then((mod) => mod.Web3AuthProvider),
  { ssr: false, loading: () => null }
);

const WalletProvider = dynamic(
  () => import("@/contexts/WalletContext").then((mod) => mod.WalletProvider),
  { ssr: false, loading: () => null }
);
```

## 🧪 Tests Performed

- [x] Test initial app load after complete Docker reset
- [x] Test load after browser page refresh
- [x] Verify Web3Auth functionality still works correctly

## ✅ Pre-merge Checklist

- [x] Code has been tested locally
- [x] No linting warnings/errors
- [x] Commits follow project conventions

## 🔍 Additional Notes

- The issue was caused by `readable-stream`, a Node.js dependency used by `@web3auth/ethereum-provider`
- Dynamic imports prevent Next.js from bundling these Node.js modules for the client
- The webpack configuration with `fallbacks` is still necessary for other polyfills but is no longer sufficient alone
- This solution is compatible with Docker and WSL