### PR TITLE
SRS ~ 3.5.5 — Fix Pagination on Criteria Selection: Block Navigation and Show Transaction Count

### DIFF
--- a/frontend/app/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/app/components/dashboard/AllTransactionsTab.tsx
@@ -280,12 +280,13 @@ export default function AllTransactionsTab({ address: propAddress }: AllTransact
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address, refreshKey]);
 
-  // When server-side class filter changes (chips), go back to page 1
+  // When server-side class filter changes (chips), reload current page with new filter
   useEffect(() => {
     if (!address) return;
-    setPage(1);
-    pageCache.current.clear(); // Clear cache when filters change
-    load(1);
+    // Don't clear cache - it's already organized by filter via getCacheKey
+    // This allows instant navigation when returning to previously visited filters
+    // Load current page with new filter (if page doesn't exist, backend will handle it)
+    load(page);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(selectedTypes)]);
 
@@ -306,8 +307,14 @@ export default function AllTransactionsTab({ address: propAddress }: AllTransact
     return Math.ceil(totalCount / PAGE_SIZE);
   }, [totalCount]);
 
-  const canPrev = page > 1;
-  const canNext = hasNext;
+  // Check if any filter is active (not "all")
+  const hasActiveFilter = useMemo(() => {
+    return !Array.isArray(selectedTypes) || (selectedTypes as any)[0] !== "all";
+  }, [selectedTypes]);
+
+  // Block navigation buttons when filters are active
+  const canPrev = !hasActiveFilter && page > 1;
+  const canNext = !hasActiveFilter && hasNext;
   const goPrev = () => {
     const p = Math.max(1, page - 1);
     setPage(p);
@@ -432,7 +439,15 @@ export default function AllTransactionsTab({ address: propAddress }: AllTransact
             </h3>
             <div className="flex items-center gap-2">
               <div className="hidden sm:flex items-center text-xs text-slate-600 mr-2">
-                {totalCount && totalPages ? (
+                {hasActiveFilter ? (
+                  loading ? (
+                    <span className="font-medium">Loading...</span>
+                  ) : (
+                    <span className="font-medium">
+                      {rows.length} transaction{rows.length !== 1 ? 's' : ''}
+                    </span>
+                  )
+                ) : totalCount && totalPages ? (
                   <span className="font-medium">
                     Page {page} of {totalPages} ({totalCount.toLocaleString()} total)
                   </span>


### PR DESCRIPTION
## 🎯 Summary

This PR fixes pagination behavior when transaction filters (expenses, incomes, etc.) are active. It blocks Next/Prev buttons and displays the transaction count instead of page numbers.

## 📋 Type of Change

- [x] 🐛 Bug fix

## 📝 Description

### ❌ Problem

**Impact**: When users select transaction filters (expenses, incomes, swap), pagination was still enabled but the total page count was unavailable (Covalent doesn't support custom filters). This created confusion as users could navigate pages without knowing the total count.

---

### ✅ Solution

The solution implements **2 complementary approaches**:

#### 1️⃣ **Disable Covalent Total Count When Filters Are Active**
- Backend detects when class filters are applied
- Returns `null` for total count instead of using Covalent (which doesn't support custom filters)
- Prevents incorrect total counts

#### 2️⃣ **Block Pagination and Show Transaction Count**
- Frontend detects when filters are active
- Disables Next/Prev buttons when filters are selected
- Displays transaction count for current page instead of "Page X of Y"
- Shows "Loading..." during data fetch

---

### 🔧 Technical Changes

#### 📁 Modified Files

| File | Changes |
|------|---------|
| `backend/src/routes/transactions.routes.ts` | Added check to disable Covalent total count when class filters are active |
| `frontend/app/components/dashboard/AllTransactionsTab.tsx` | Added filter detection, blocked pagination buttons, updated display logic |

---

#### 🔑 Key Changes

**Before:**
```typescript
// Backend always used Covalent
const totalCountPromise = getTransactionCountTotal({...});

// Frontend allowed navigation with filters
const canPrev = page > 1;
const canNext = hasNext;
```

**After:**
```typescript
// Backend skips Covalent when filters are active
const hasClassFilter = !!classParam;
const totalCountPromise = hasClassFilter
  ? Promise.resolve(null)
  : getTransactionCountTotal({...});

// Frontend blocks navigation with filters
const hasActiveFilter = !Array.isArray(selectedTypes) || selectedTypes[0] !== "all";
const canPrev = !hasActiveFilter && page > 1;
const canNext = !hasActiveFilter && hasNext;
```

## 🔗 Link to ticket/issue

<!-- If applicable -->
Closes #[ticket-number]

## 🧪 Tests Performed

- [x] Verified Next/Prev buttons are disabled when filters are active
- [x] Verified transaction count displays correctly when filters are active
- [x] Verified "Loading..." appears during data fetch with filters
- [x] Verified pagination works normally when no filters are selected
- [x] Verified Covalent total count is disabled when filters are active

## 📸 Screenshots / Demo

<!-- If applicable, add screenshots or GIFs -->

## ✅ Pre-merge Checklist

- [x] Code has been tested locally
- [x] Tests pass
- [x] Documentation has been updated if necessary
- [x] No linting warnings/errors
- [x] Commits follow project conventions

## 🔍 Additional Notes

- When filters are active, users can only view the current page (no pagination)
- Total transaction count is not available with filters (Covalent limitation)
- Cache is preserved per filter combination for instant navigation when returning to previously visited filters