### PR TITLE
Feature/multi wallet tsx and ratios

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,10 +13,10 @@ import networksRouter from "./routes/networks.routes";
 
 const app = express();
 
-// Increase timeout for long-running requests (multi-network requests without cap can take longer)
+// Increase timeout for long-running requests (pricing API calls can take 20-30s)
 app.use((req, res, next) => {
-  req.setTimeout(300000); // 5 minutes
-  res.setTimeout(300000);
+  req.setTimeout(120000); // 2 minutes
+  res.setTimeout(120000);
   next();
 });
 

--- a/backend/src/routes/analytics.routes.ts
+++ b/backend/src/routes/analytics.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { getMultiNetworkHistoricalPortfolio } from "../services/historical.service";
 import { parseNetworks } from "../config/networks";
+import { getPricingWarnings } from "../services/pricing.service";
 
 // Toggle verbose analytics/debug logs. When false only concise errors are printed.
 const LOGS_DEBUG = (process.env.LOGS_DEBUG ?? "false") === "true";
@@ -44,6 +45,7 @@ router.get("/historical/:address", async (req, res) => {
       days,
       data,
       isEstimated,
+      warnings: getPricingWarnings(),
     });
   } catch (err: any) {
     dbg("[GET /api/analytics/historical/:address] error:", err);

--- a/backend/src/routes/transactions.routes.ts
+++ b/backend/src/routes/transactions.routes.ts
@@ -10,6 +10,7 @@ import {
   encodeCursorFromLeg,
   isLegOlderThanCursor,
 } from "../utils/tx.cursor";
+import { getPricingWarnings } from "../services/pricing.service";
 
 const router = Router();
 
@@ -157,6 +158,7 @@ router.get("/:address", async (req, res) => {
       limit,
       hasNext,
       nextCursor,
+      warnings: getPricingWarnings(),
     });
     
     // Single summary log with key metrics

--- a/backend/src/services/holdings.service.ts
+++ b/backend/src/services/holdings.service.ts
@@ -11,6 +11,7 @@ import {
   getNativePriceUsd,
   normalizeContractKey,
   getPricesAtTimestamp,
+  getPricingWarnings,
 } from "./pricing.service";
 
 const TOKEN_API_BASE =
@@ -40,6 +41,11 @@ type PricedHolding = {
   priceSource: "native" | "map" | "tokenapi" | "unknown";
 };
 
+type PricingWarnings = {
+  defiLlamaRateLimited?: boolean;
+  defiLlamaRetryAfterMs?: number;
+};
+
 type OverviewResponse = {
   address: string;
   asOf: string;
@@ -58,6 +64,7 @@ type OverviewResponse = {
     weightPct: number;
     chain: EvmNetwork;
   }[];
+  warnings?: PricingWarnings;
 };
 
 async function tokenApiGET<T>(
@@ -375,5 +382,6 @@ export async function getHoldingsOverview(
     holdings,
     allocation,
     topHoldings,
+    warnings: getPricingWarnings(),
   };
 }

--- a/frontend/app/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/app/components/dashboard/AllTransactionsTab.tsx
@@ -329,6 +329,7 @@ export default function AllTransactionsTab({
             goPrev={goPrev}
             goNext={goNext}
             walletLabels={walletLabelLookup}
+            loadedRowsAll={cache.loadedRowsAll}
           />
         </div>
       </Card>

--- a/frontend/app/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/app/components/dashboard/AllTransactionsTab.tsx
@@ -51,13 +51,6 @@ export default function AllTransactionsTab({
     );
   }, [totalCount, stats.capitalGainsSummary.transactionsCount]);
 
-  const hasActiveWallets = activeWallets.length > 0;
-  const hasNoTransactions =
-    hasActiveWallets &&
-    cache.loadedRowsAll.length === 0 &&
-    !cache.loading &&
-    !cache.error;
-
   useEffect(() => {
     if (cache.error) {
       console.error("[AllTransactionsTab] Error:", {
@@ -183,7 +176,6 @@ export default function AllTransactionsTab({
                 walletDropdownVisible ? walletLimitReached : undefined
               }
               walletLimit={walletDropdownVisible ? walletLimit : undefined}
-              hasNoTransactions={hasNoTransactions}
             />
           </div>
 
@@ -276,9 +268,7 @@ export default function AllTransactionsTab({
                   id="type-all"
                   checked={(filters.selectedTypes as any)[0] === "all"}
                   onCheckedChange={(c) => filters.toggleType("all", !!c)}
-                  disabled={
-                    cache.loading || filters.isOnlyAllSelected || hasNoTransactions
-                  }
+                  disabled={cache.loading || filters.isOnlyAllSelected}
                 />
                 <Label htmlFor="type-all" className="text-sm font-medium">
                   All types
@@ -302,7 +292,7 @@ export default function AllTransactionsTab({
                     onCheckedChange={(c) =>
                       filters.toggleType(t as TxType, !!c)
                     }
-                    disabled={cache.loading || hasNoTransactions}
+                    disabled={cache.loading}
                   />
                   <Label
                     htmlFor={`type-${t}`}

--- a/frontend/app/components/dashboard/AllTransactionsTab.tsx
+++ b/frontend/app/components/dashboard/AllTransactionsTab.tsx
@@ -1,235 +1,56 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import type { TxType } from "@/lib/types/transactions";
-import { useTransactionFilters } from "@/hooks/useTransactionFilters";
-import { useTransactionCache } from "@/hooks/useTransactionCache";
-import { useTransactionStats } from "@/hooks/useTransactionStats";
 import { CapitalGainsSnapshot } from "./CapitalGainsSnapshot";
 import { TransactionToolbar } from "./TransactionToolbar";
 import { TransactionTable } from "./TransactionTable";
-import { typeIcon, shortAddr } from "@/utils/transactionHelpers";
-
-const DEFAULT_MULTI_WALLET_LIMIT = Number(
-  process.env.NEXT_PUBLIC_DASHBOARD_MULTI_LIMIT ?? 3
-);
-
-const WALLET_COLOR_PALETTE = [
-  "#6366f1",
-  "#f97316",
-  "#0ea5e9",
-  "#14b8a6",
-  "#ec4899",
-  "#84cc16",
-];
-
-interface WalletOption {
-  address: string;
-  label: string;
-  color?: string;
-}
+import FinancialRatiosPanel from "./FinancialRatiosPanel";
+import { typeIcon, shortAddr, fmtUSD } from "@/utils/transactionHelpers";
+import { useTransactionsWorkspace } from "./TransactionsWorkspaceProvider";
 
 interface AllTransactionsTabProps {
-  address?: string;
-  networks?: string; // comma-separated override; omit to use UI-managed selection
-  walletOptions?: WalletOption[];
-  walletLimit?: number;
+  totalAssetsUsd: number | null;
+  stableHoldingsUsd: number;
 }
 
 export default function AllTransactionsTab({
-  address: propAddress,
-  networks: propNetworks,
-  walletOptions,
-  walletLimit = DEFAULT_MULTI_WALLET_LIMIT,
+  totalAssetsUsd,
+  stableHoldingsUsd,
 }: AllTransactionsTabProps) {
-  // Use prop address if provided, otherwise read from URL
-  const [address, setAddress] = useState<string>(propAddress || "");
-
-  useEffect(() => {
-    if (propAddress) {
-      setAddress(propAddress);
-    } else {
-      const urlParams = new URLSearchParams(window.location.search);
-      setAddress(urlParams.get("address") || "");
-    }
-  }, [propAddress]);
-
-  const [refreshKey, setRefreshKey] = useState(0);
-  const walletOptionList = useMemo(() => {
-    if (!walletOptions?.length) return [];
-    return walletOptions.map((wallet, idx) => ({
-      ...wallet,
-      label: wallet.label || shortAddr(wallet.address),
-      color:
-        wallet.color ??
-        WALLET_COLOR_PALETTE[idx % WALLET_COLOR_PALETTE.length],
-    }));
-  }, [walletOptions]);
-  const [selectedWallets, setSelectedWallets] = useState<string[]>(() =>
-    walletOptions && walletOptions.length
-      ? walletOptions.map((wallet) => wallet.address)
-      : propAddress
-      ? [propAddress]
-      : []
-  );
-
-  useEffect(() => {
-    if (walletOptionList.length) {
-      setSelectedWallets((prev) => {
-        const valid = prev.filter((addr) =>
-          walletOptionList.some((wallet) => wallet.address === addr)
-        );
-        if (valid.length) return valid;
-        return walletOptionList
-          .map((wallet) => wallet.address)
-          .slice(0, walletLimit);
-      });
-    } else if (propAddress) {
-      setSelectedWallets([propAddress]);
-    } else {
-      setSelectedWallets([]);
-    }
-  }, [walletOptionList, walletLimit, propAddress]);
-
-  const activeWallets = selectedWallets.length
-    ? selectedWallets
-    : address
-    ? [address]
-    : [];
-
-  const walletDropdownVisible = walletOptionList.length > 1;
-  const walletSelectionCount = selectedWallets.length;
-  const walletLimitReached = walletSelectionCount >= walletLimit;
-
-  const walletMap = useMemo(() => {
-    const map = new Map<string, WalletOption & { color?: string }>();
-    walletOptionList.forEach((wallet) => {
-      map.set(wallet.address, wallet);
-      map.set(wallet.address.toLowerCase(), wallet);
-    });
-    return map;
-  }, [walletOptionList]);
-
-  const walletLabelLookup = useMemo(() => {
-    const lookup: Record<string, { label: string; color?: string }> = {};
-    walletOptionList.forEach((wallet) => {
-      lookup[wallet.address.toLowerCase()] = {
-        label: wallet.label,
-        color: wallet.color,
-      };
-    });
-    return lookup;
-  }, [walletOptionList]);
-
-  const walletButtonLabel = useMemo(() => {
-    if (!walletDropdownVisible) {
-      const single = activeWallets[0];
-      const meta = single ? walletMap.get(single) : null;
-      return meta?.label || (single ? shortAddr(single) : "Wallet");
-    }
-    if (!walletSelectionCount) {
-      return "None selected";
-    }
-    if (walletSelectionCount === walletOptionList.length) {
-      return "All wallets";
-    }
-    if (walletSelectionCount === 1) {
-      const meta = walletMap.get(selectedWallets[0]);
-      return meta?.label || shortAddr(selectedWallets[0]);
-    }
-    const first = walletMap.get(selectedWallets[0]);
-    const baseLabel = first?.label || shortAddr(selectedWallets[0]);
-    return `${baseLabel} +${walletSelectionCount - 1}`;
-  }, [
-    walletDropdownVisible,
-    walletSelectionCount,
-    walletOptionList.length,
+  const {
+    address,
     activeWallets,
-    walletMap,
+    walletOptionList,
+    walletDropdownVisible,
+    walletButtonLabel,
+    walletLimitReached,
+    walletLimit,
+    walletLabelLookup,
     selectedWallets,
-  ]);
-
-  const toggleWalletSelection = (addr: string, checked: boolean) => {
-    setSelectedWallets((prev) => {
-      if (checked) {
-        if (prev.includes(addr)) return prev;
-        if (walletLimitReached) return prev;
-        return [...prev, addr];
-      }
-      return prev.filter((item) => item !== addr);
-    });
-  };
-
-  const selectAllWallets = () => {
-    if (!walletOptionList.length) return;
-    setSelectedWallets(
-      walletOptionList.map((wallet) => wallet.address).slice(0, walletLimit)
+    toggleWalletSelection,
+    selectAllWallets,
+    resetWalletSelection,
+    exportLabel,
+    filters,
+    cache,
+    stats,
+    totalCount,
+    canPrev,
+    canNext,
+    goPrev,
+    goNext,
+    setRefreshKey,
+  } = useTransactionsWorkspace();
+  const coveragePct = useMemo(() => {
+    if (!totalCount || totalCount <= 0) return null;
+    return Math.min(
+      1,
+      stats.capitalGainsSummary.transactionsCount / totalCount
     );
-  };
+  }, [totalCount, stats.capitalGainsSummary.transactionsCount]);
 
-  const resetWalletSelection = () => {
-    if (!walletOptionList.length) return;
-    setSelectedWallets(
-      walletOptionList.map((wallet) => wallet.address).slice(0, walletLimit)
-    );
-  };
-
-  const exportLabel = useMemo(() => {
-    if (activeWallets.length === 1) {
-      return shortAddr(activeWallets[0]);
-    }
-    if (activeWallets.length > 1) {
-      return `${activeWallets.length}-wallets`;
-    }
-    return "wallets";
-  }, [activeWallets]);
-
-  // Filters hook
-  const filters = useTransactionFilters(propNetworks);
-
-  // Cache hook
-  const cache = useTransactionCache({
-    addresses: activeWallets,
-    selectedTypes: filters.selectedTypes,
-    networksParam: filters.networksParam,
-    dateRange: filters.dateRange,
-    dateRangeKey: filters.dateRangeKey,
-    selectedTypesKey: filters.selectedTypesKey,
-    refreshKey,
-  });
-
-  // Stats hook
-  const stats = useTransactionStats(cache.loadedRowsAll);
-
-  // Use total from backend (Covalent) if available, otherwise fallback to estimation
-  const totalCount = useMemo(() => {
-    if (cache.total !== null) return cache.total; // Use real total from backend
-    // Fallback to estimation if backend total not available
-    if (cache.rows.length === 0) return null;
-    if (cache.hasNext) {
-      return cache.page * 20; // At least this many
-    } else {
-      return (cache.page - 1) * 20 + cache.rows.length; // Exact count
-    }
-  }, [cache.total, cache.page, cache.hasNext, cache.rows.length]);
-
-  // Navigation buttons - now work with filters since filtering is done client-side
-  const canPrev = cache.page > 1;
-  const canNext =
-    cache.hasNext && !(cache.loading && cache.page >= cache.maxLoadedPage);
-  const goPrev = () => {
-    const p = Math.max(1, cache.page - 1);
-    cache.setPage(p);
-    cache.load(p);
-  };
-  const goNext = () => {
-    const p = cache.page + 1;
-    cache.setPage(p);
-    cache.load(p);
-  };
-
-  // Log only significant state changes (errors or page changes)
   useEffect(() => {
     if (cache.error) {
       console.error("[AllTransactionsTab] Error:", {
@@ -243,50 +64,75 @@ export default function AllTransactionsTab({
 
   return (
     <div className="space-y-6">
-      {activeWallets.length > 0 && (
-        <CapitalGainsSnapshot
-          address={exportLabel}
-          loadedTransactionsCount={stats.capitalGainsSummary.transactionsCount}
+      <div
+        className={`grid gap-6 ${
+          activeWallets.length ? "lg:grid-cols-2" : "lg:grid-cols-1"
+        }`}
+      >
+        {activeWallets.length > 0 && (
+          <CapitalGainsSnapshot
+            address={exportLabel}
+            loadedTransactionsCount={
+              stats.capitalGainsSummary.transactionsCount
+            }
+            totalCount={totalCount}
+            dateRangeLabel={filters.dateRange.label}
+            capitalGainsSummary={stats.capitalGainsSummary}
+            incomeBreakdown={stats.incomeBreakdown}
+            counterpartyBreakdown={stats.counterpartyBreakdown}
+            gasVsProceeds={stats.gasVsProceeds}
+            stableBufferStats={stats.stableBufferStats}
+            costBasisBuckets={stats.costBasisBuckets}
+            washSaleSignals={stats.washSaleSignals}
+            unmatchedSales={stats.capitalGainsSummary.unmatchedSales}
+          />
+        )}
+        <FinancialRatiosPanel
+          totalAssetsUsd={totalAssetsUsd}
+          stableHoldingsUsd={stableHoldingsUsd}
+          stats={stats}
+          cache={cache}
+          filters={filters}
           totalCount={totalCount}
-          dateRangeLabel={filters.dateRange.label}
-          capitalGainsSummary={stats.capitalGainsSummary}
-          incomeBreakdown={stats.incomeBreakdown}
-          counterpartyBreakdown={stats.counterpartyBreakdown}
-          gasVsProceeds={stats.gasVsProceeds}
-          stableBufferStats={stats.stableBufferStats}
-          costBasisBuckets={stats.costBasisBuckets}
-          washSaleSignals={stats.washSaleSignals}
-          unmatchedSales={stats.capitalGainsSummary.unmatchedSales}
+          hasActiveWallets={activeWallets.length > 0}
         />
-      )}
+      </div>
 
       <Card className="bg-white shadow-sm">
-        <div className="p-6 border-b">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-xl font-bold text-slate-800">
-              All Transactions {activeWallets.length ? "" : "(select a wallet)"}
-            </h3>
-            {walletOptionList.length > 0 && activeWallets.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2">
-                {activeWallets.map((walletAddress) => {
-                  const meta =
-                    walletMap.get(walletAddress) ||
-                    walletMap.get(walletAddress.toLowerCase());
-                  return (
-                    <span
-                      key={walletAddress}
-                      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-700"
-                    >
+        <div className="p-6 space-y-6">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h3 className="text-xl font-bold text-slate-800">
+                All Transactions{" "}
+                <span className="text-sm font-normal text-slate-500">
+                  {filters.dateRange.label}
+                </span>
+              </h3>
+              <p className="text-sm text-slate-500">
+                Review every ledger entry, refine filters, then export or run
+                ratios using the controls on the right.
+              </p>
+              {walletOptionList.length > 0 && activeWallets.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-3">
+                  {activeWallets.map((walletAddress) => {
+                    const meta =
+                      walletLabelLookup[walletAddress.toLowerCase()] || null;
+                    return (
                       <span
-                        className="inline-block w-2 h-2 rounded-full"
-                        style={{ backgroundColor: meta?.color || "#94a3b8" }}
-                      />
-                      {meta?.label || shortAddr(walletAddress)}
-                    </span>
-                  );
-                })}
-              </div>
-            )}
+                        key={walletAddress}
+                        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs text-slate-700"
+                      >
+                        <span
+                          className="inline-block w-2 h-2 rounded-full"
+                          style={{ backgroundColor: meta?.color || "#94a3b8" }}
+                        />
+                        {meta?.label || shortAddr(walletAddress)}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
             <TransactionToolbar
               exportLabel={exportLabel}
               loading={cache.loading}
@@ -314,9 +160,7 @@ export default function AllTransactionsTab({
               goNext={goNext}
               refresh={cache.refresh}
               setRefreshKey={setRefreshKey}
-              walletOptions={
-                walletDropdownVisible ? walletOptionList : undefined
-              }
+              walletOptions={walletDropdownVisible ? walletOptionList : undefined}
               selectedWallets={selectedWallets}
               walletButtonLabel={walletButtonLabel}
               toggleWalletSelection={
@@ -335,8 +179,49 @@ export default function AllTransactionsTab({
             />
           </div>
 
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs uppercase text-slate-500 tracking-wide">
+                Loaded transactions
+              </p>
+              <p className="text-2xl font-semibold text-slate-900">
+                {stats.capitalGainsSummary.transactionsCount.toLocaleString()}
+              </p>
+              <p className="text-xs text-slate-500">
+                Page {cache.page} · {filters.networksButtonLabel}
+              </p>
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs uppercase text-slate-500 tracking-wide">
+                Coverage vs estimate
+              </p>
+              <p className="text-2xl font-semibold text-slate-900">
+                {coveragePct != null
+                  ? `${Math.round(coveragePct * 100)}%`
+                  : "—"}
+              </p>
+              {totalCount && (
+                <p className="text-xs text-slate-500">
+                  {stats.capitalGainsSummary.transactionsCount.toLocaleString()}{" "}
+                  / {totalCount.toLocaleString()}
+                </p>
+              )}
+            </div>
+            <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
+              <p className="text-xs uppercase text-slate-500 tracking-wide">
+                Current selection value
+              </p>
+              <p className="text-2xl font-semibold text-slate-900">
+                {totalAssetsUsd != null ? fmtUSD(totalAssetsUsd) : "—"}
+              </p>
+              <p className="text-xs text-slate-500">
+                Based on latest overview snapshot
+              </p>
+            </div>
+          </div>
+
           {filters.datePreset === "custom" && (
-            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <div className="grid gap-4 sm:grid-cols-2">
               <label className="text-xs text-slate-600 font-medium flex flex-col gap-1">
                 <span>From</span>
                 <input
@@ -362,59 +247,82 @@ export default function AllTransactionsTab({
             </div>
           )}
 
-          {/* Filter chips (server-side class filter) */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
-            <div className="flex items-center space-x-2">
-              <Checkbox
-                id="type-all"
-                checked={(filters.selectedTypes as any)[0] === "all"}
-                onCheckedChange={(c) => filters.toggleType("all", !!c)}
-                disabled={cache.loading || filters.isOnlyAllSelected}
-              />
-              <Label htmlFor="type-all" className="text-sm font-normal">
-                All Types
-              </Label>
-            </div>
-            {["income", "expense", "swap", "gas"].map((t) => (
-              <div key={t} className="flex items-center space-x-2">
-                <Checkbox
-                  id={`type-${t}`}
-                  checked={
-                    Array.isArray(filters.selectedTypes) &&
-                    (filters.selectedTypes as any)[0] !== "all"
-                      ? (filters.selectedTypes as TxType[]).includes(
-                          t as TxType
-                        )
-                      : false
-                  }
-                  onCheckedChange={(c) => filters.toggleType(t as TxType, !!c)}
-                  disabled={cache.loading}
-                />
-                <Label
-                  htmlFor={`type-${t}`}
-                  className="text-sm font-normal capitalize flex items-center gap-1"
+          <div className="rounded-xl border border-slate-200 bg-slate-50/50 p-4 space-y-4">
+            <div className="flex items-center justify-between flex-wrap gap-2">
+              <p className="text-sm font-semibold text-slate-800">
+                Transaction types
+              </p>
+              {!filters.filterIsAll && (
+                <button
+                  type="button"
+                  className="text-xs text-slate-500 underline"
+                  onClick={() => filters.toggleType("all", true)}
                 >
-                  {typeIcon(t as TxType)} {t}
+                  Clear filters
+                </button>
+              )}
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
+              <div className="flex items-center space-x-2 rounded-lg border border-slate-200 bg-white px-3 py-2">
+                <Checkbox
+                  id="type-all"
+                  checked={(filters.selectedTypes as any)[0] === "all"}
+                  onCheckedChange={(c) => filters.toggleType("all", !!c)}
+                  disabled={cache.loading || filters.isOnlyAllSelected}
+                />
+                <Label htmlFor="type-all" className="text-sm font-medium">
+                  All types
                 </Label>
               </div>
-            ))}
+              {["income", "expense", "swap", "gas"].map((t) => (
+                <div
+                  key={t}
+                  className="flex items-center space-x-2 rounded-lg border border-slate-200 bg-white px-3 py-2"
+                >
+                  <Checkbox
+                    id={`type-${t}`}
+                    checked={
+                      Array.isArray(filters.selectedTypes) &&
+                      (filters.selectedTypes as any)[0] !== "all"
+                        ? (filters.selectedTypes as TxType[]).includes(
+                            t as TxType
+                          )
+                        : false
+                    }
+                    onCheckedChange={(c) =>
+                      filters.toggleType(t as TxType, !!c)
+                    }
+                    disabled={cache.loading}
+                  />
+                  <Label
+                    htmlFor={`type-${t}`}
+                    className="text-sm font-medium capitalize flex items-center gap-1"
+                  >
+                    {typeIcon(t as TxType)} {t}
+                  </Label>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
 
-        <TransactionTable
-          address={activeWallets.length ? exportLabel : null}
-          rows={cache.rows}
-          loading={cache.loading}
-          error={cache.error}
-          visibleColumns={filters.visibleColumns}
-          visibleColumnsInit={filters.visibleColumnsInit}
-          canPrev={canPrev}
-          canNext={canNext}
-          goPrev={goPrev}
-          goNext={goNext}
-          walletLabels={walletLabelLookup}
-        />
+        <div className="border-t border-slate-100">
+          <TransactionTable
+            address={activeWallets.length ? exportLabel : null}
+            rows={cache.rows}
+            loading={cache.loading}
+            error={cache.error}
+            visibleColumns={filters.visibleColumns}
+            visibleColumnsInit={filters.visibleColumnsInit}
+            canPrev={canPrev}
+            canNext={canNext}
+            goPrev={goPrev}
+            goNext={goNext}
+            walletLabels={walletLabelLookup}
+          />
+        </div>
       </Card>
+
     </div>
   );
 }

--- a/frontend/app/components/dashboard/CapitalGainsSnapshot.tsx
+++ b/frontend/app/components/dashboard/CapitalGainsSnapshot.tsx
@@ -285,9 +285,9 @@ export function CapitalGainsSnapshot({
                 </p>
                 {unmatchedSales.length ? (
                   <ul className="mt-2 space-y-2 text-sm text-slate-700">
-                    {unmatchedSales.slice(0, 3).map((sale, idx) => (
+                    {unmatchedSales.slice(0, 3).map((sale) => (
                       <li
-                        key={`${sale.transactionId}-${sale.saleDate}-${sale.asset}-${sale.quantity}-${idx}`}
+                        key={`${sale.transactionId}-${sale.saleDate}`}
                         className="flex items-center justify-between"
                       >
                         <span>

--- a/frontend/app/components/dashboard/FinancialRatiosPanel.tsx
+++ b/frontend/app/components/dashboard/FinancialRatiosPanel.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useMemo } from "react";
+import { Card } from "@/components/ui/card";
+import { fmtUSD, fmtPct, DAY_MS } from "@/utils/transactionHelpers";
+import type { useTransactionStats } from "@/hooks/useTransactionStats";
+import type { useTransactionCache } from "@/hooks/useTransactionCache";
+import type { useTransactionFilters } from "@/hooks/useTransactionFilters";
+
+type StatsReturn = ReturnType<typeof useTransactionStats>;
+type CacheReturn = ReturnType<typeof useTransactionCache>;
+type FiltersReturn = ReturnType<typeof useTransactionFilters>;
+
+interface FinancialRatiosPanelProps {
+  totalAssetsUsd: number | null;
+  stableHoldingsUsd: number;
+  stats: StatsReturn;
+  cache: CacheReturn;
+  filters: FiltersReturn;
+  totalCount: number | null;
+  hasActiveWallets: boolean;
+}
+
+function RatioCard({
+  title,
+  value,
+  formula,
+  details,
+  note,
+}: {
+  title: string;
+  value: string;
+  formula: string;
+  details: Array<{ label: string; value: string }>;
+  note?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 p-4 bg-slate-50/60">
+      <p className="text-xs uppercase tracking-wide text-slate-500">
+        {formula}
+      </p>
+      <h4 className="mt-1 text-xl font-semibold text-slate-900">{value}</h4>
+      <p className="text-sm font-medium text-slate-700 mt-1">{title}</p>
+      <dl className="mt-3 space-y-1 text-xs text-slate-600">
+        {details.map((detail) => (
+          <div key={detail.label} className="flex justify-between gap-2">
+            <dt>{detail.label}</dt>
+            <dd className="font-semibold text-slate-800">{detail.value}</dd>
+          </div>
+        ))}
+      </dl>
+      {note && <p className="mt-3 text-xs text-slate-500">{note}</p>}
+    </div>
+  );
+}
+
+export default function FinancialRatiosPanel({
+  totalAssetsUsd,
+  stableHoldingsUsd,
+  stats,
+  cache,
+  filters,
+  totalCount,
+  hasActiveWallets,
+}: FinancialRatiosPanelProps) {
+  const coveragePct =
+    totalCount && totalCount > 0
+      ? Math.min(
+          1,
+          stats.capitalGainsSummary.transactionsCount / totalCount
+        )
+      : null;
+  const coveragePctDisplay =
+    coveragePct != null ? Math.round(coveragePct * 100) : null;
+
+  const flowStats = useMemo(() => {
+    let expenseTotal = 0;
+    let minTs: number | null = null;
+    let maxTs: number | null = null;
+    cache.loadedRowsAll.forEach((row) => {
+      if (row.type === "expense" && row.direction === "out") {
+        expenseTotal += row.usdAtTs ?? 0;
+      }
+      const ts = Date.parse(row.ts);
+      if (!Number.isNaN(ts)) {
+        if (minTs == null || ts < minTs) minTs = ts;
+        if (maxTs == null || ts > maxTs) maxTs = ts;
+      }
+    });
+    const spanDays =
+      minTs != null && maxTs != null
+        ? Math.max(1, Math.round((maxTs - minTs) / DAY_MS) + 1)
+        : 0;
+    return { expenseTotal, spanDays };
+  }, [cache.loadedRowsAll]);
+
+  const totalIncome = stats.incomeBreakdown.total ?? 0;
+  const totalExpenses = flowStats.expenseTotal;
+  const gasTotal = stats.gasVsProceeds.gas ?? 0;
+  const netIncome = totalIncome - totalExpenses - gasTotal;
+  const netMargin =
+    totalIncome > 0 ? netIncome / totalIncome : null;
+  const assetTurnover =
+    totalAssetsUsd && totalAssetsUsd > 0
+      ? totalIncome / totalAssetsUsd
+      : null;
+  const roa =
+    totalAssetsUsd && totalAssetsUsd > 0
+      ? netIncome / totalAssetsUsd
+      : null;
+
+  const avgDailyBurn =
+    flowStats.spanDays > 0 ? (totalExpenses + gasTotal) / flowStats.spanDays : null;
+  const daysOfSufficiency =
+    avgDailyBurn && avgDailyBurn > 0
+      ? stableHoldingsUsd / avgDailyBurn
+      : null;
+
+  const gasCoverage =
+    stats.gasVsProceeds.proceeds > 0
+      ? (stats.gasVsProceeds.proceeds - stats.gasVsProceeds.gas) /
+        stats.gasVsProceeds.proceeds
+      : null;
+
+  const unavailableRatios = [
+    {
+      title: "Return on Equity (ROE)",
+      reason:
+        "Requires shareholder equity or retained earnings, which wallets do not expose.",
+    },
+    {
+      title: "Current & Quick Ratios",
+      reason:
+        "Need current asset/liability schedules beyond on-chain balances.",
+    },
+    {
+      title: "Cash Conversion Cycle",
+      reason:
+        "No on-chain receivables, payables, or inventory turnover data.",
+    },
+    {
+      title: "Breakeven, Operating & Financial Leverage",
+      reason:
+        "Missing fixed vs variable cost split, EBIT history, and formal debt balances.",
+    },
+  ];
+
+  const ratioCards = [
+    {
+      id: "net-margin",
+      title: "Net Margin",
+      value: netMargin != null ? fmtPct(netMargin) : "—",
+      formula: "Net income / total income",
+      details: [
+        {
+          label: "Net income",
+          value: fmtUSD(netIncome),
+        },
+        { label: "Total income", value: fmtUSD(totalIncome) },
+      ],
+      note:
+        totalIncome === 0
+          ? "Requires at least one income transaction in the loaded sample."
+          : "Income includes on-chain inflows classified as income events.",
+    },
+    {
+      id: "asset-turnover",
+      title: "Asset Turnover",
+      value:
+        assetTurnover != null ? `${assetTurnover.toFixed(2)}×` : "—",
+      formula: "Total income / total assets",
+      details: [
+        { label: "Total income", value: fmtUSD(totalIncome) },
+        {
+          label: "Total assets",
+          value:
+            totalAssetsUsd != null ? fmtUSD(totalAssetsUsd) : "—",
+        },
+      ],
+      note:
+        totalAssetsUsd == null
+          ? "Portfolio value unavailable — refresh overview to sync holdings."
+          : "Assets taken from the latest overview snapshot, not an audited balance sheet.",
+    },
+    {
+      id: "roa",
+      title: "Return on Assets (ROA)",
+      value: roa != null ? fmtPct(roa) : "—",
+      formula: "Net income / total assets",
+      details: [
+        { label: "Net income", value: fmtUSD(netIncome) },
+        {
+          label: "Total assets",
+          value:
+            totalAssetsUsd != null ? fmtUSD(totalAssetsUsd) : "—",
+        },
+      ],
+      note:
+        totalAssetsUsd == null
+          ? "Requires a current portfolio valuation."
+          : "Treats wallet value as an equity proxy — taxes and off-chain liabilities not included.",
+    },
+    {
+      id: "sufficiency",
+      title: "Days of Sufficiency",
+      value:
+        daysOfSufficiency != null
+          ? `${daysOfSufficiency.toFixed(1)} days`
+          : "—",
+      formula: "Liquid reserves / avg daily burn",
+      details: [
+        { label: "Liquid reserves", value: fmtUSD(stableHoldingsUsd) },
+        {
+          label: "Avg daily burn",
+          value:
+            avgDailyBurn != null ? fmtUSD(avgDailyBurn) : "—",
+        },
+      ],
+      note:
+        flowStats.spanDays === 0
+          ? "Load at least two days of transactions to estimate burn rate."
+          : "Liquid reserves use current stablecoin holdings across connected wallets.",
+    },
+    {
+      id: "gas-coverage",
+      title: "Gas Coverage",
+      value: gasCoverage != null ? fmtPct(gasCoverage) : "—",
+      formula: "(Proceeds − gas fees) / proceeds",
+      details: [
+        { label: "Proceeds", value: fmtUSD(stats.gasVsProceeds.proceeds) },
+        { label: "Gas spend", value: fmtUSD(stats.gasVsProceeds.gas) },
+      ],
+      note:
+        stats.gasVsProceeds.proceeds === 0
+          ? "Need at least one outbound transaction in the sample."
+          : "Highlights how much gross outflow is lost to network fees.",
+    },
+  ];
+
+  return (
+    <Card className="bg-white shadow-sm">
+      <div className="p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="text-xl font-bold text-slate-800">
+              Financial Ratios
+            </h3>
+            <p className="text-sm text-slate-500">
+              Based on loaded transactions for {filters.dateRange.label}. Load
+              additional pages to improve coverage.
+            </p>
+          </div>
+          <div className="text-sm text-slate-500">
+            Page {cache.page} • {filters.networksButtonLabel}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3 mt-6">
+          <div>
+            <p className="text-xs uppercase text-slate-500">Loaded tx</p>
+            <p className="text-2xl font-semibold text-slate-900">
+              {stats.capitalGainsSummary.transactionsCount.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-slate-500">
+              Coverage vs estimate
+            </p>
+            <p className="text-2xl font-semibold text-slate-900">
+              {coveragePctDisplay != null ? `${coveragePctDisplay}%` : "—"}
+            </p>
+            {totalCount && (
+              <p className="text-xs text-slate-500">
+                {stats.capitalGainsSummary.transactionsCount.toLocaleString()}{" "}
+                / {totalCount.toLocaleString()}
+              </p>
+            )}
+          </div>
+          <div>
+            <p className="text-xs uppercase text-slate-500">Active window</p>
+            <p className="text-2xl font-semibold text-slate-900">
+              {flowStats.spanDays > 0 ? `${flowStats.spanDays} days` : "—"}
+            </p>
+          </div>
+        </div>
+
+        {coveragePct != null && (
+          <div className="mt-4">
+            <div className="flex items-center justify-between text-xs text-slate-500 mb-1">
+              <span>Loaded vs estimated total</span>
+              <span>{coveragePctDisplay}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-slate-100 overflow-hidden">
+              <div
+                className="h-2 bg-indigo-500"
+                style={{
+                  width: `${Math.min(coveragePct * 100, 100)}%`,
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {!hasActiveWallets ? (
+          <p className="mt-6 text-sm text-slate-600">
+            Select at least one wallet to compute ratios. Use the wallet picker
+            in the toolbar above.
+          </p>
+        ) : (
+          <div className="mt-6 space-y-6">
+            <div className="grid gap-4 md:grid-cols-2">
+              {ratioCards.map((ratio) => (
+                <RatioCard key={ratio.id} {...ratio} />
+              ))}
+            </div>
+            <p className="text-xs text-slate-500">
+              These ratios are illustrative only and rely on the loaded
+              transactions plus the latest portfolio snapshot. Taxes,
+              off-chain liabilities, and historical accounting entries are out
+              of scope for this wallet-native view.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-slate-100 px-6 py-4 bg-slate-50/80">
+        <h4 className="text-sm font-semibold text-slate-800 mb-2">
+          Ratios unavailable with current data
+        </h4>
+        <ul className="list-disc pl-5 space-y-1 text-sm text-slate-600">
+          {unavailableRatios.map((item) => (
+            <li key={item.title}>
+              <span className="font-medium text-slate-800">{item.title}:</span>{" "}
+              {item.reason}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/components/dashboard/TransactionTable.tsx
+++ b/frontend/app/components/dashboard/TransactionTable.tsx
@@ -32,7 +32,6 @@ interface TransactionTableProps {
   goPrev: () => void;
   goNext: () => void;
   walletLabels?: Record<string, { label: string; color?: string }>;
-  loadedRowsAll: TxRow[];
 }
 
 export function TransactionTable({
@@ -47,7 +46,6 @@ export function TransactionTable({
   goPrev,
   goNext,
   walletLabels,
-  loadedRowsAll,
 }: TransactionTableProps) {
   if (!address) {
     return (
@@ -102,45 +100,8 @@ export function TransactionTable({
     return <div className="p-6 text-sm text-red-600">{error}</div>;
   }
 
-  if (rows.length === 0 && !loading) {
-    // Check if there are transactions in cache but none match the current filter
-    const hasTransactionsInCache = loadedRowsAll.length > 0;
-
-    if (hasTransactionsInCache) {
-      // Transactions exist in cache but none match the current filter
-      return (
-        <div className="p-12 text-center">
-          <div className="flex flex-col items-center gap-3">
-            <div className="text-slate-400 text-4xl">🔍</div>
-            <div className="text-slate-600 font-medium">
-              No transactions match the current filters
-            </div>
-            <div className="text-sm text-slate-500">
-              Try adjusting your filters to see more transactions. There are{" "}
-              {loadedRowsAll.length} transaction
-              {loadedRowsAll.length !== 1 ? "s" : ""} available with different
-              filters.
-            </div>
-          </div>
-        </div>
-      );
-    } else {
-      // No transactions in the wallet at all
-      return (
-        <div className="p-12 text-center">
-          <div className="flex flex-col items-center gap-3">
-            <div className="text-slate-400 text-4xl">📭</div>
-            <div className="text-slate-600 font-medium">
-              No transactions found
-            </div>
-            <div className="text-sm text-slate-500">
-              No transactions match the current filters. Try adjusting your
-              filters or date range.
-            </div>
-          </div>
-        </div>
-      );
-    }
+  if (rows.length === 0) {
+    return null;
   }
 
   return (

--- a/frontend/app/components/dashboard/TransactionTable.tsx
+++ b/frontend/app/components/dashboard/TransactionTable.tsx
@@ -31,6 +31,7 @@ interface TransactionTableProps {
   canNext: boolean;
   goPrev: () => void;
   goNext: () => void;
+  walletLabels?: Record<string, { label: string; color?: string }>;
 }
 
 export function TransactionTable({
@@ -44,11 +45,12 @@ export function TransactionTable({
   canNext,
   goPrev,
   goNext,
+  walletLabels,
 }: TransactionTableProps) {
   if (!address) {
     return (
       <div className="p-6 text-sm text-slate-500">
-        Enter an address on the Overview tab to load transactions.
+        Select at least one wallet to load transactions.
       </div>
     );
   }
@@ -67,7 +69,9 @@ export function TransactionTable({
               {visibleColumns.qty && <TableHead>Qty</TableHead>}
               {visibleColumns.usd && <TableHead>USD @ time</TableHead>}
               {visibleColumns.fee && <TableHead>Gas (USD)</TableHead>}
-              {visibleColumns.counterparty && <TableHead>Counterparty</TableHead>}
+              {visibleColumns.counterparty && (
+                <TableHead>Counterparty</TableHead>
+              )}
               {visibleColumns.tx && <TableHead>Tx</TableHead>}
             </TableRow>
           </TableHeader>
@@ -161,18 +165,28 @@ export function TransactionTable({
                     </div>
                   ) : (
                     tx.asset?.symbol ||
-                    (tx.asset?.contract
-                      ? shortAddr(tx.asset.contract)
-                      : "—")
+                    (tx.asset?.contract ? shortAddr(tx.asset.contract) : "—")
+                  )}
+                  {tx.walletAddress && (
+                    <span className="mt-1 flex items-center gap-1 text-[11px] text-slate-500">
+                      <span
+                        className="inline-block w-1.5 h-1.5 rounded-full"
+                        style={{
+                          backgroundColor:
+                            walletLabels?.[tx.walletAddress.toLowerCase()]
+                              ?.color ?? "#94a3b8",
+                        }}
+                      />
+                      {walletLabels?.[tx.walletAddress.toLowerCase()]?.label ??
+                        shortAddr(tx.walletAddress)}
+                    </span>
                   )}
                 </TableCell>
               )}
               {visibleColumns.qty && (
                 <TableCell
                   className={`font-mono ${
-                    tx.direction === "in"
-                      ? "text-green-600"
-                      : "text-red-600"
+                    tx.direction === "in" ? "text-green-600" : "text-red-600"
                   }`}
                 >
                   {fmtQty(tx.qty, tx.direction)}
@@ -213,14 +227,23 @@ export function TransactionTable({
 
       {/* Pager footer (mobile) */}
       <div className="flex sm:hidden justify-end gap-2 p-3">
-        <Button variant="outline" size="sm" onClick={goPrev} disabled={!canPrev}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={goPrev}
+          disabled={!canPrev}
+        >
           Prev
         </Button>
-        <Button variant="outline" size="sm" onClick={goNext} disabled={!canNext}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={goNext}
+          disabled={!canNext}
+        >
           Next
         </Button>
       </div>
     </div>
   );
 }
-

--- a/frontend/app/components/dashboard/TransactionToolbar.tsx
+++ b/frontend/app/components/dashboard/TransactionToolbar.tsx
@@ -59,7 +59,6 @@ interface TransactionToolbarProps {
   resetWalletSelection?: () => void;
   walletLimitReached?: boolean;
   walletLimit?: number;
-  hasNoTransactions?: boolean;
 }
 
 export function TransactionToolbar({
@@ -97,7 +96,6 @@ export function TransactionToolbar({
   resetWalletSelection,
   walletLimitReached,
   walletLimit,
-  hasNoTransactions = false,
 }: TransactionToolbarProps) {
   return (
     <div className="flex items-center gap-2">
@@ -247,71 +245,67 @@ export function TransactionToolbar({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      {!hasNoTransactions && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
-              <Eye className="w-4 h-4 mr-2" /> Columns
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            {(
-              Object.keys(visibleColumns) as Array<
-                keyof typeof visibleColumnsInit
-              >
-            ).map((key) => (
-              <DropdownMenuCheckboxItem
-                key={key}
-                checked={visibleColumns[key]}
-                onCheckedChange={(checked) =>
-                  setVisibleColumns((prev) => ({
-                    ...prev,
-                    [key]: !!checked,
-                  }))
-                }
-              >
-                {String(key).charAt(0).toUpperCase() + String(key).slice(1)}
-              </DropdownMenuCheckboxItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <Eye className="w-4 h-4 mr-2" /> Columns
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {(
+            Object.keys(visibleColumns) as Array<
+              keyof typeof visibleColumnsInit
+            >
+          ).map((key) => (
+            <DropdownMenuCheckboxItem
+              key={key}
+              checked={visibleColumns[key]}
+              onCheckedChange={(checked) =>
+                setVisibleColumns((prev) => ({
+                  ...prev,
+                  [key]: !!checked,
+                }))
+              }
+            >
+              {String(key).charAt(0).toUpperCase() + String(key).slice(1)}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-      {!hasNoTransactions && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm">
-              Export
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <button
-              className="w-full text-left px-2 py-1.5 hover:bg-slate-50"
-              onClick={() =>
-                exportCsv(exportLabel, rows, "visible", typeLabelForExport)
-              }
-            >
-              CSV (visible)
-            </button>
-            <div className="h-px bg-slate-200 my-1" />
-            <button
-              className="w-full text-left px-2 py-1.5 hover:bg-slate-50"
-              onClick={() =>
-                exportJson(exportLabel, rows, "visible", typeLabelForExport)
-              }
-            >
-              JSON (visible)
-            </button>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            Export
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-56">
+          <button
+            className="w-full text-left px-2 py-1.5 hover:bg-slate-50"
+            onClick={() =>
+              exportCsv(exportLabel, rows, "visible", typeLabelForExport)
+            }
+          >
+            CSV (visible)
+          </button>
+          <div className="h-px bg-slate-200 my-1" />
+          <button
+            className="w-full text-left px-2 py-1.5 hover:bg-slate-50"
+            onClick={() =>
+              exportJson(exportLabel, rows, "visible", typeLabelForExport)
+            }
+          >
+            JSON (visible)
+          </button>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <div className="hidden sm:flex items-center gap-1">
         <Button
           variant="outline"
           size="sm"
           onClick={goPrev}
-          disabled={!canPrev || loading || hasNoTransactions}
+          disabled={!canPrev || loading}
         >
           Prev
         </Button>
@@ -319,7 +313,7 @@ export function TransactionToolbar({
           variant="outline"
           size="sm"
           onClick={goNext}
-          disabled={!canNext || loading || hasNoTransactions}
+          disabled={!canNext || loading}
         >
           Next
         </Button>

--- a/frontend/app/components/dashboard/TransactionsWorkspaceProvider.tsx
+++ b/frontend/app/components/dashboard/TransactionsWorkspaceProvider.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import { shortAddr } from "@/utils/transactionHelpers";
+import { useTransactionFilters } from "@/hooks/useTransactionFilters";
+import { useTransactionCache } from "@/hooks/useTransactionCache";
+import { useTransactionStats } from "@/hooks/useTransactionStats";
+
+const DEFAULT_MULTI_WALLET_LIMIT = Number(
+  process.env.NEXT_PUBLIC_DASHBOARD_MULTI_LIMIT ?? 3
+);
+
+const WALLET_COLOR_PALETTE = [
+  "#6366f1",
+  "#f97316",
+  "#0ea5e9",
+  "#14b8a6",
+  "#ec4899",
+  "#84cc16",
+];
+
+export interface WalletOption {
+  address: string;
+  label: string;
+  color?: string;
+}
+
+interface TransactionsWorkspaceProviderProps {
+  children: ReactNode;
+  address?: string;
+  networks?: string;
+  walletOptions?: WalletOption[];
+  walletLimit?: number;
+}
+
+interface TransactionsWorkspaceValue {
+  address: string;
+  activeWallets: string[];
+  walletOptionList: WalletOption[];
+  selectedWallets: string[];
+  walletDropdownVisible: boolean;
+  walletButtonLabel: string;
+  walletLimitReached: boolean;
+  walletLimit: number;
+  walletLabelLookup: Record<string, { label: string; color?: string }>;
+  toggleWalletSelection: (addr: string, checked: boolean) => void;
+  selectAllWallets: () => void;
+  resetWalletSelection: () => void;
+  exportLabel: string;
+  filters: ReturnType<typeof useTransactionFilters>;
+  cache: ReturnType<typeof useTransactionCache>;
+  stats: ReturnType<typeof useTransactionStats>;
+  totalCount: number | null;
+  canPrev: boolean;
+  canNext: boolean;
+  goPrev: () => void;
+  goNext: () => void;
+  refreshKey: number;
+  setRefreshKey: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const TransactionsWorkspaceContext =
+  createContext<TransactionsWorkspaceValue | null>(null);
+
+export function TransactionsWorkspaceProvider({
+  children,
+  address: propAddress,
+  networks: propNetworks,
+  walletOptions,
+  walletLimit: walletLimitProp,
+}: TransactionsWorkspaceProviderProps) {
+  const walletLimit =
+    typeof walletLimitProp === "number"
+      ? walletLimitProp
+      : DEFAULT_MULTI_WALLET_LIMIT;
+
+  const [address, setAddress] = useState<string>(propAddress || "");
+  useEffect(() => {
+    if (propAddress) {
+      setAddress(propAddress);
+    } else {
+      const params = new URLSearchParams(window.location.search);
+      setAddress(params.get("address") || "");
+    }
+  }, [propAddress]);
+
+  const walletOptionList = useMemo(() => {
+    if (!walletOptions?.length) return [];
+    return walletOptions.map((wallet, idx) => ({
+      ...wallet,
+      label: wallet.label || shortAddr(wallet.address),
+      color:
+        wallet.color ??
+        WALLET_COLOR_PALETTE[idx % WALLET_COLOR_PALETTE.length],
+    }));
+  }, [walletOptions]);
+
+  const [selectedWallets, setSelectedWallets] = useState<string[]>(() => {
+    if (walletOptionList.length) {
+      return walletOptionList
+        .map((wallet) => wallet.address)
+        .slice(0, walletLimit);
+    }
+    return propAddress ? [propAddress] : [];
+  });
+
+  useEffect(() => {
+    if (walletOptionList.length) {
+      setSelectedWallets((prev) => {
+        const valid = prev.filter((addr) =>
+          walletOptionList.some((wallet) => wallet.address === addr)
+        );
+        if (valid.length) return valid;
+        return walletOptionList
+          .map((wallet) => wallet.address)
+          .slice(0, walletLimit);
+      });
+    } else if (propAddress) {
+      setSelectedWallets([propAddress]);
+    } else {
+      setSelectedWallets([]);
+    }
+  }, [walletOptionList, walletLimit, propAddress]);
+
+  const activeWallets = selectedWallets.length
+    ? selectedWallets
+    : address
+    ? [address]
+    : [];
+
+  const walletDropdownVisible = walletOptionList.length > 1;
+  const walletSelectionCount = selectedWallets.length;
+  const walletLimitReached = walletSelectionCount >= walletLimit;
+
+  const walletLabelLookup = useMemo(() => {
+    const lookup: Record<string, { label: string; color?: string }> = {};
+    walletOptionList.forEach((wallet) => {
+      lookup[wallet.address.toLowerCase()] = {
+        label: wallet.label,
+        color: wallet.color,
+      };
+    });
+    return lookup;
+  }, [walletOptionList]);
+
+  const walletButtonLabel = useMemo(() => {
+    if (!walletDropdownVisible) {
+      const single = activeWallets[0];
+      const meta = single ? walletLabelLookup[single.toLowerCase()] : null;
+      return meta?.label || (single ? shortAddr(single) : "Wallet");
+    }
+    if (!walletSelectionCount) {
+      return "None selected";
+    }
+    if (walletSelectionCount === walletOptionList.length) {
+      return "All wallets";
+    }
+    if (walletSelectionCount === 1) {
+      const meta = walletLabelLookup[selectedWallets[0]?.toLowerCase() ?? ""];
+      return meta?.label || shortAddr(selectedWallets[0]);
+    }
+    const first = selectedWallets[0];
+    const meta = first ? walletLabelLookup[first.toLowerCase()] : null;
+    const baseLabel = meta?.label || (first ? shortAddr(first) : "Wallets");
+    return `${baseLabel} +${walletSelectionCount - 1}`;
+  }, [
+    walletDropdownVisible,
+    activeWallets,
+    walletLabelLookup,
+    walletSelectionCount,
+    walletOptionList.length,
+    selectedWallets,
+  ]);
+
+  const toggleWalletSelection = useCallback(
+    (addr: string, checked: boolean) => {
+      setSelectedWallets((prev) => {
+        if (checked) {
+          if (prev.includes(addr)) return prev;
+          if (walletLimitReached) return prev;
+          return [...prev, addr];
+        }
+        return prev.filter((item) => item !== addr);
+      });
+    },
+    [walletLimitReached]
+  );
+
+  const selectAllWallets = useCallback(() => {
+    if (!walletOptionList.length) return;
+    setSelectedWallets(
+      walletOptionList.map((wallet) => wallet.address).slice(0, walletLimit)
+    );
+  }, [walletOptionList, walletLimit]);
+
+  const resetWalletSelection = useCallback(() => {
+    if (!walletOptionList.length) return;
+    setSelectedWallets(
+      walletOptionList.map((wallet) => wallet.address).slice(0, walletLimit)
+    );
+  }, [walletOptionList, walletLimit]);
+
+  const exportLabel = useMemo(() => {
+    if (activeWallets.length === 1) {
+      return shortAddr(activeWallets[0]);
+    }
+    if (activeWallets.length > 1) {
+      return `${activeWallets.length}-wallets`;
+    }
+    return "wallets";
+  }, [activeWallets]);
+
+  const filters = useTransactionFilters(propNetworks);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const cache = useTransactionCache({
+    addresses: activeWallets,
+    selectedTypes: filters.selectedTypes,
+    networksParam: filters.networksParam,
+    dateRange: filters.dateRange,
+    dateRangeKey: filters.dateRangeKey,
+    selectedTypesKey: filters.selectedTypesKey,
+    refreshKey,
+  });
+  const stats = useTransactionStats(cache.loadedRowsAll);
+
+  const totalCount = useMemo(() => {
+    if (cache.total !== null) return cache.total;
+    if (cache.rows.length === 0) return null;
+    if (cache.hasNext) {
+      return cache.page * 20;
+    }
+    return (cache.page - 1) * 20 + cache.rows.length;
+  }, [cache.total, cache.page, cache.hasNext, cache.rows.length]);
+
+  const canPrev = cache.page > 1;
+  const canNext =
+    cache.hasNext && !(cache.loading && cache.page >= cache.maxLoadedPage);
+
+  const goPrev = useCallback(() => {
+    const p = Math.max(1, cache.page - 1);
+    cache.setPage(p);
+    cache.load(p);
+  }, [cache]);
+
+  const goNext = useCallback(() => {
+    const p = cache.page + 1;
+    cache.setPage(p);
+    cache.load(p);
+  }, [cache]);
+
+  const value = useMemo<TransactionsWorkspaceValue>(
+    () => ({
+      address,
+      activeWallets,
+      walletOptionList,
+      selectedWallets,
+      walletDropdownVisible,
+      walletButtonLabel,
+      walletLimitReached,
+      walletLimit,
+      walletLabelLookup,
+      toggleWalletSelection,
+      selectAllWallets,
+      resetWalletSelection,
+      exportLabel,
+      filters,
+      cache,
+      stats,
+      totalCount,
+      canPrev,
+      canNext,
+      goPrev,
+      goNext,
+      refreshKey,
+      setRefreshKey,
+    }),
+    [
+      address,
+      activeWallets,
+      walletOptionList,
+      selectedWallets,
+      walletDropdownVisible,
+      walletButtonLabel,
+      walletLimitReached,
+      walletLimit,
+      walletLabelLookup,
+      toggleWalletSelection,
+      selectAllWallets,
+      resetWalletSelection,
+      exportLabel,
+      filters,
+      cache,
+      stats,
+      totalCount,
+      canPrev,
+      canNext,
+      goPrev,
+      goNext,
+      refreshKey,
+      setRefreshKey,
+    ]
+  );
+
+  return (
+    <TransactionsWorkspaceContext.Provider value={value}>
+      {children}
+    </TransactionsWorkspaceContext.Provider>
+  );
+}
+
+export function useTransactionsWorkspace() {
+  const ctx = useContext(TransactionsWorkspaceContext);
+  if (!ctx) {
+    throw new Error(
+      "useTransactionsWorkspace must be used within TransactionsWorkspaceProvider"
+    );
+  }
+  return ctx;
+}

--- a/frontend/app/components/dashboard/TransactionsWorkspaceProvider.tsx
+++ b/frontend/app/components/dashboard/TransactionsWorkspaceProvider.tsx
@@ -39,6 +39,7 @@ interface TransactionsWorkspaceProviderProps {
   networks?: string;
   walletOptions?: WalletOption[];
   walletLimit?: number;
+  onPricingWarningChange?: (flag: boolean) => void;
 }
 
 interface TransactionsWorkspaceValue {
@@ -65,6 +66,7 @@ interface TransactionsWorkspaceValue {
   goNext: () => void;
   refreshKey: number;
   setRefreshKey: React.Dispatch<React.SetStateAction<number>>;
+  pricingWarnings: ReturnType<typeof useTransactionCache>["warnings"] | null;
 }
 
 const TransactionsWorkspaceContext =
@@ -76,6 +78,7 @@ export function TransactionsWorkspaceProvider({
   networks: propNetworks,
   walletOptions,
   walletLimit: walletLimitProp,
+  onPricingWarningChange,
 }: TransactionsWorkspaceProviderProps) {
   const walletLimit =
     typeof walletLimitProp === "number"
@@ -231,6 +234,18 @@ export function TransactionsWorkspaceProvider({
   });
   const stats = useTransactionStats(cache.loadedRowsAll);
 
+  useEffect(() => {
+    if (!onPricingWarningChange) return;
+    onPricingWarningChange(!!cache.warnings?.defiLlamaRateLimited);
+  }, [cache.warnings, onPricingWarningChange]);
+
+  useEffect(() => {
+    if (!onPricingWarningChange) return;
+    return () => {
+      onPricingWarningChange(false);
+    };
+  }, [onPricingWarningChange]);
+
   const totalCount = useMemo(() => {
     if (cache.total !== null) return cache.total;
     if (cache.rows.length === 0) return null;
@@ -281,6 +296,7 @@ export function TransactionsWorkspaceProvider({
       goNext,
       refreshKey,
       setRefreshKey,
+      pricingWarnings: cache.warnings,
     }),
     [
       address,

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -339,7 +339,7 @@ const Dashboard = () => {
   const [walletLabelMode, setWalletLabelMode] = useState<"name" | "address">(
     "name"
   );
-const [walletStats, setWalletStats] = useState<WalletStat[]>([]);
+  const [walletStats, setWalletStats] = useState<WalletStat[]>([]);
   const [loadedFromStorage, setLoadedFromStorage] = useState(false);
   const handleToggleWallet = (walletAddress: string, checked: boolean) => {
     setSelectedWallets((prev) => {
@@ -380,7 +380,9 @@ const [walletStats, setWalletStats] = useState<WalletStat[]>([]);
 
   const handleSelectAllWallets = () => {
     if (urlAddress) return;
-    const next = allWallets.slice(0, MAX_MULTI_WALLETS).map((wallet) => wallet.address);
+    const next = allWallets
+      .slice(0, MAX_MULTI_WALLETS)
+      .map((wallet) => wallet.address);
     setSelectedWallets(next);
     setWalletSelectionDirty(true);
   };
@@ -1443,14 +1445,17 @@ const [walletStats, setWalletStats] = useState<WalletStat[]>([]);
                 </div>
                 <div className="flex flex-col items-end text-xs text-slate-500 gap-1">
                   <span>
-                    Aggregating {aggregatedWalletCount} / {MAX_MULTI_WALLETS} wallets
+                    Aggregating {aggregatedWalletCount} / {MAX_MULTI_WALLETS}{" "}
+                    wallets
                   </span>
-                  {walletSelectionDirty && selectedWallets.length > 0 && !urlAddress && (
-                    <span className="inline-flex items-center gap-1 text-amber-600">
-                      <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-500" />
-                      Apply the new selection to refresh data
-                    </span>
-                  )}
+                  {walletSelectionDirty &&
+                    selectedWallets.length > 0 &&
+                    !urlAddress && (
+                      <span className="inline-flex items-center gap-1 text-amber-600">
+                        <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-500" />
+                        Apply the new selection to refresh data
+                      </span>
+                    )}
                 </div>
                 {walletLimitReached && (
                   <p className="text-xs text-amber-600">
@@ -1725,7 +1730,11 @@ const [walletStats, setWalletStats] = useState<WalletStat[]>([]);
           </TabsContent> */}
 
           <TabsContent value="all-transactions" forceMount>
-            <AllTransactionsTab address={address} />
+            <AllTransactionsTab
+              address={address}
+              walletOptions={appliedWalletDisplay}
+              walletLimit={MAX_MULTI_WALLETS}
+            />
           </TabsContent>
         </Tabs>
       </main>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import CapitalGainsTab from "@/components/dashboard/CapitalGainsTab";
 import AllTransactionsTab from "@/components/dashboard/AllTransactionsTab";
 import OverviewTab from "@/components/dashboard/OverviewTab";
 import GraphsTab from "@/components/dashboard/GraphsTab";
+import { TransactionsWorkspaceProvider } from "@/components/dashboard/TransactionsWorkspaceProvider";
 import {
   CapitalGainsCalculator,
   type CapitalGainEntry,
@@ -1187,6 +1188,8 @@ const Dashboard = () => {
       assetCount: counts[id],
     }));
   }, [ov]);
+  const stableBucketUsd =
+    riskBuckets.find((bucket) => bucket.id === "stable")?.usd ?? 0;
 
   const appliedWalletDisplay = useMemo(() => {
     const list = urlAddress
@@ -1728,13 +1731,17 @@ const Dashboard = () => {
               currency={userPreferences.currency}
             />
           </TabsContent> */}
-
           <TabsContent value="all-transactions" forceMount>
-            <AllTransactionsTab
+            <TransactionsWorkspaceProvider
               address={address}
               walletOptions={appliedWalletDisplay}
               walletLimit={MAX_MULTI_WALLETS}
-            />
+            >
+              <AllTransactionsTab
+                totalAssetsUsd={ov?.kpis.totalValueUsd ?? null}
+                stableHoldingsUsd={stableBucketUsd}
+              />
+            </TransactionsWorkspaceProvider>
           </TabsContent>
         </Tabs>
       </main>

--- a/frontend/app/hooks/useTransactionCache.ts
+++ b/frontend/app/hooks/useTransactionCache.ts
@@ -150,11 +150,11 @@ export function useTransactionCache({
   const isOverloaded =
     cachedAheadCount >= 3 || (loading && cachedAheadCount >= 1);
   const loadIndicatorLabel = isOverloaded
-    ? `Préchargement élevé: ${cachedAheadCount} page(s)`
+    ? `High prefetch load: ${cachedAheadCount} page(s)`
     : cachedAheadCount > 0
-    ? `Pages en cache: ${cachedAheadCount}`
+    ? `Pages cached: ${cachedAheadCount}`
     : loading
-    ? `Chargement…`
+    ? `Loading…`
     : null;
 
   // Generate all possible filter combinations

--- a/frontend/app/hooks/useTransactionCache.ts
+++ b/frontend/app/hooks/useTransactionCache.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from "react";
-import type { TxRow, TxType } from "@/lib/types/transactions";
+import type { TxRow, TxType, TxListResponse } from "@/lib/types/transactions";
 import { fetchTransactions } from "@/lib/api/transactions";
 import { PAGE_SIZE, uiTypesToClassParam } from "@/utils/transactionHelpers";
 
@@ -72,6 +72,9 @@ export function useTransactionCache({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [total, setTotal] = useState<number | null>(null);
+  const [warnings, setWarnings] = useState<TxListResponse["warnings"] | null>(
+    null
+  );
 
   // Generate base cache key (without selectedTypes): "address:networks:dateRange"
   const getBaseCacheKey = useCallback(() => {
@@ -418,7 +421,11 @@ export function useTransactionCache({
             ...(dateRange.to ? { to: dateRange.to } : {}),
           });
 
-          const { rows: newRows, nextCursor } = resp as any;
+        const { rows: newRows, nextCursor, warnings: respWarnings } =
+          resp as any;
+        if (respWarnings) {
+          setWarnings(respWarnings);
+        }
           totalCandidates.push((resp as any)?.total ?? null);
 
           if (Array.isArray(newRows) && newRows.length) {
@@ -651,5 +658,6 @@ export function useTransactionCache({
     cachedAheadCount,
     isOverloaded,
     loadIndicatorLabel,
+    warnings,
   };
 }

--- a/frontend/app/lib/api/analytics.ts
+++ b/frontend/app/lib/api/analytics.ts
@@ -12,6 +12,10 @@ export type HistoricalResponse = {
   days: number;
   data: HistoricalPoint[];
   isEstimated?: boolean;
+  warnings?: {
+    defiLlamaRateLimited?: boolean;
+    defiLlamaRetryAfterMs?: number;
+  };
 };
 
 export async function fetchHistoricalData(

--- a/frontend/app/lib/api/transactions.ts
+++ b/frontend/app/lib/api/transactions.ts
@@ -88,5 +88,6 @@ export async function fetchTransactions(address: string, q: TxQuery) {
     hasNext,
     gasMeta: json.meta?.gasUsdByTx ?? {},
     nextCursor: json.nextCursor ?? null,
+    warnings: json.warnings,
   };
 }

--- a/frontend/app/lib/types/portfolio.ts
+++ b/frontend/app/lib/types/portfolio.ts
@@ -38,4 +38,8 @@ export type OverviewResponse = {
     weightPct: number;
     chain: PricedHolding["chain"];
   }[];
+  warnings?: {
+    defiLlamaRateLimited?: boolean;
+    defiLlamaRetryAfterMs?: number;
+  };
 };

--- a/frontend/app/lib/types/transactions.ts
+++ b/frontend/app/lib/types/transactions.ts
@@ -54,4 +54,8 @@ export interface TxListResponse {
   limit: number;
   hasNext?: boolean;
   nextCursor?: string | null;
+  warnings?: {
+    defiLlamaRateLimited?: boolean;
+    defiLlamaRetryAfterMs?: number;
+  };
 }

--- a/frontend/app/lib/types/transactions.ts
+++ b/frontend/app/lib/types/transactions.ts
@@ -6,6 +6,7 @@ export interface TxRow {
   blockNumber: number;
   hash: string;
   network: string; // e.g. "mainnet"
+  walletAddress?: string;
   direction: Direction;
   type: TxType; // UI bucket (transfer_in -> income, transfer_out -> expense)
   asset: {

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -34,7 +34,7 @@ server {
     proxy_pass $backend;
 
     proxy_connect_timeout 2s;
-    proxy_read_timeout 300s;
-    proxy_send_timeout 300s;
+    proxy_read_timeout 120s;
+    proxy_send_timeout 120s;
   }
 }


### PR DESCRIPTION
Summary
Surface DeFiLlama rate-limit issues across the app so users understand why USD prices/24h deltas may show zero.

Backend now records rate-limit warnings when DeFiLlama returns 429 (spot & historical) and includes that metadata on holdings, transactions, and historical endpoints.
Frontend types and API helpers carry the new warnings payload through hooks/components; the dashboard aggregates signals from overview, historical, and transaction data and displays a prominent alert when pricing falls back.
TransactionsWorkspaceProvider forwards warnings from the transaction cache so the All Transactions tab contributes to the shared alert state.
Improve the All Transactions tab layout and UX:

Capital Gains snapshot and Financial Ratios panel sit side-by-side at the top, giving users a cohesive summary before the filter/table.
Header now includes descriptive copy plus wallet chips; added quick stats row and a more structured type-filter panel.
Stabilize shared state helpers to avoid infinite React re-renders:

Refined pricing-warning state updates to avoid toggling state every render/emission.
Minor UI polish: translated cache-status strings to English, Wire up new alert components.

Testing
Manual testing in dashboard:
Verified normal flow (no warnings) still shows standard layout.
Simulated rate-limit warning (mocked responses) -> alert banner appears once.
Toggled wallet/date/network filters to ensure warning state doesn’t loop or regress All Transactions view.